### PR TITLE
add x-translator extension to some entries, remove translator tag fro…

### DIFF
--- a/CTD_api/CTD_openapi.yml
+++ b/CTD_api/CTD_openapi.yml
@@ -12,7 +12,8 @@ info:
   version: 0.0.1
 tags:
   - name: query
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
 paths:
   '/CTD_chem_gene_ixns_CasRN/{CasRN}/':
     get:

--- a/GT_cmaq_exposures_api/cmaq_exposures_openapi.yml
+++ b/GT_cmaq_exposures_api/cmaq_exposures_openapi.yml
@@ -16,7 +16,8 @@ info:
 tags:
   - name: exposures
   - name: cmaq
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
 paths:
   /variables:
     get:

--- a/GT_endotypes_api/endotypes_openapi.yml
+++ b/GT_endotypes_api/endotypes_openapi.yml
@@ -18,7 +18,8 @@ tags:
   - name: patient
   - name: endotype
   - name: query
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
 paths:
   /endotypes:
     post:

--- a/GT_exposures_api/exposures_openapi.yml
+++ b/GT_exposures_api/exposures_openapi.yml
@@ -17,7 +17,8 @@ tags:
   - name: environment
   - name: exposure
   - name: query
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
 paths:
   /cmaq:
     get:

--- a/biolink/openapi.yml
+++ b/biolink/openapi.yml
@@ -9,6 +9,11 @@ info:
   termsOfService: https://github.com/monarch-initiative/biolink-api/
   title: BioLink API
   version: 0.1.1
+  x-translator:
+    component: KP
+    team:
+    ## check what teams are involved
+    - "Standards Reference Implementation Team"  
 servers:
 - description: Production server
   url: https://api.monarchinitiative.org/api

--- a/broad-pgm/openapi.yml
+++ b/broad-pgm/openapi.yml
@@ -10,9 +10,10 @@ info:
     email: translator@broadinstitute.org
     x-role: responsible organization
     x-id: 'https://github.com/broadinstitute/broad-translator'
-  version: 0.1.0
+  version: 0.1.0    
 tags:
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
 paths:
   /modelList:
     get:

--- a/dgidb/openapi.yml
+++ b/dgidb/openapi.yml
@@ -9,6 +9,10 @@ info:
   termsOfService: https://biothings.io/about
   title: BioThings DGIdb API
   version: '1.0'
+  x-translator:
+    component: KP
+    team:
+      - Service Provider
 servers:
 - description: Encrypted Production server
   url: https://biothings.ncats.io/dgidb

--- a/disease ontology api/openapi.yml
+++ b/disease ontology api/openapi.yml
@@ -16,7 +16,8 @@ tags:
   - name: disease
   - name: ontology
   - name: annotation
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
 paths:
   '/metadata/{doid}':
     get:

--- a/ebi_ontology_lookup_service_api/openapi.yml
+++ b/ebi_ontology_lookup_service_api/openapi.yml
@@ -16,7 +16,8 @@ servers:
 tags:
   - name: ontology
   - name: query
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
 paths:
   /query:
     get:

--- a/ebi_proteins/openapi.yml
+++ b/ebi_proteins/openapi.yml
@@ -22,7 +22,8 @@ tags:
   - name: variation
   - name: genecentric
   - name: proteins
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
 paths:
   /antigen:
     get:

--- a/ebi_proteins_taxonomy/openapi.yml
+++ b/ebi_proteins_taxonomy/openapi.yml
@@ -14,7 +14,8 @@ info:
     url: https://groups.google.com/forum/#!forum/ebi-proteins-api
 tags:
   - name: taxonomy
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
 paths:
   '/ancestor/{ids}':
     get:

--- a/ensembl/openapi.yml
+++ b/ensembl/openapi.yml
@@ -17,7 +17,8 @@ tags:
   - name: phenotype
   - name: variant
   - name: genotype
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
 paths:
   '/variation/human/{dbsnp}?phenotypes=1':
     get:

--- a/indigo/openapi.yml
+++ b/indigo/openapi.yml
@@ -21,7 +21,8 @@ tags:
     description: Query reasoner using a predefined question type
   - name: predicates
     description: Get all supported relationships in the knowledge graph, organized by source and target
-  - name: translator
+## deprecate this registry entry?
+#   - name: translator
   - name: reasoner
 paths:
   /query:

--- a/mychem.info/mychem_auto.yaml
+++ b/mychem.info/mychem_auto.yaml
@@ -10,6 +10,10 @@ info:
     x-role: responsible developer
     email: help@biothings.io
     x-id: https://github.com/newgene
+  x-translator:
+    component: KP
+    team:
+      - Service Provider
 servers:
 - url: http://MyChem.info/v1
   description: Production server

--- a/mychem.info/openapi_minimum.yml
+++ b/mychem.info/openapi_minimum.yml
@@ -11,6 +11,10 @@ info:
     x-role: responsible developer
     email: help@mychem.info
     x-id: 'https://github.com/newgene'
+  x-translator:
+    component: KP
+    team:
+    - Service Provider
 servers:
   - url: 'http://mychem.info/v1'
     description: 'Production server'

--- a/mygene.info/openapi_full_temp.yml
+++ b/mygene.info/openapi_full_temp.yml
@@ -13,6 +13,10 @@ info:
     x-id:
       - 'http://orcid.org/0000-0002-2629-6124'
       - 'https://github.com/newgene'
+  x-translator:
+    component: KP
+    team:
+      - Service Provider
 servers:
   - url: 'http://mygene.info/v3'
     description: 'Production server'

--- a/mygene.info/openapi_minimum.yml
+++ b/mygene.info/openapi_minimum.yml
@@ -11,6 +11,10 @@ info:
     x-role: responsible developer
     email: help@mygene.info
     x-id: 'https://github.com/newgene'
+  x-translator:
+    component: KP
+    team:
+      - Service Provider
 servers:
   - url: 'http://mygene.info/v3'
     description: 'Production server'

--- a/myvariant.info/openapi_full_temp.yml
+++ b/myvariant.info/openapi_full_temp.yml
@@ -11,6 +11,10 @@ info:
     x-role: responsible developer
     email: help@myvariant.info
     x-id: 'https://github.com/newgene'
+  x-translator:
+    component: KP
+    team:
+      - Service Provider
 servers:
   - url: 'http://myvariant.info/v1'
     description: 'Production server'

--- a/myvariant.info/openapi_minimum.yml
+++ b/myvariant.info/openapi_minimum.yml
@@ -11,6 +11,10 @@ info:
     x-role: responsible developer
     email: help@myvariant.info
     x-id: 'https://github.com/newgene'
+  x-translator:
+    component: KP
+    team:
+      - Service Provider    
 servers:
   - url: 'http://myvariant.info/v1'
     description: 'Production server'


### PR DESCRIPTION
…m old APIs. 

Added x-translator extension to:
- biolink API **(check that team is only SRI)**
- mychem.info (auto and minimum files)
- mygene.info (full_temp and minimum files)
- myvariant.info (full_temp and minimum files)

Removed translator tag from the old APIs:
broad-pgm
CTD_api
disease ontology api
ebi_ontology_lookup_service_api
ebi_proteins
ebi_proteins_taxonomy
ensembl
GT_cmaq_exposures_api
GT_endotypes_api
GT_exposures_api
indigo