### PR TITLE
fix error in predicate

### DIFF
--- a/mygene.info/openapi_full.yml
+++ b/mygene.info/openapi_full.yml
@@ -676,7 +676,7 @@ components:
         parameters: 
           fields: entrezgene
           species: human
-        predicate: participant_in
+        predicate: has_participant
         requestBody: 
           body: 
             q: "{inputs[0]}"


### PR DESCRIPTION
"participant in" doesn't exist as a biolink predicate. Fixing this error. 