### PR TITLE
Updates to Text Mining Provider registry items related to TRAPI 1.1 upgrade

### DIFF
--- a/text_mining/cooccurrence.yaml
+++ b/text_mining/cooccurrence.yaml
@@ -5,7 +5,7 @@ info:
     name: Bill Baumgartner
     x-id: https://github.com/bill-baumgartner/
     x-role: responsible developer
-  description: Documentation of the Text Mining Targeted Association query web services.
+  description: Documentation of the Text Mining Provider concept cooccurrence query web services.
   termsOfService: https://biothings.io/about
   title: Text Mining CO-OCCURRENCE API
   version: '1.0'

--- a/text_mining/cooccurrence.yaml
+++ b/text_mining/cooccurrence.yaml
@@ -18,6 +18,8 @@ info:
   x-trapi:
     version: 1.1.0
 servers:
+- description: TRAPI endpoint
+  url: https://smart-api.info/ui/5be0f321a829792e934545998b9c6afe
 - description: Encrypted Production server
   url: https://biothings.ncats.io/text_mining_co_occurrence_kp
 - description: Production server

--- a/text_mining/cooccurrence.yaml
+++ b/text_mining/cooccurrence.yaml
@@ -14,6 +14,9 @@ info:
     team:
       - Text Mining Provider
       - Service Provider
+    biolink-version: 1.5.0
+  x-trapi:
+    version: 1.1.0
 servers:
 - description: Encrypted Production server
   url: https://biothings.ncats.io/text_mining_co_occurrence_kp

--- a/text_mining/cooccurrence.yaml
+++ b/text_mining/cooccurrence.yaml
@@ -19,7 +19,7 @@ info:
     version: 1.1.0
 servers:
 - description: TRAPI endpoint
-  url: https://smart-api.info/ui/5be0f321a829792e934545998b9c6afe
+  url: https://api.bte.ncats.io/v1/smartapi/5be0f321a829792e934545998b9c6afe
 - description: Encrypted Production server
   url: https://biothings.ncats.io/text_mining_co_occurrence_kp
 - description: Production server

--- a/text_mining/cooccurrence.yaml
+++ b/text_mining/cooccurrence.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.0
 info:
   contact:
-    email: help@biothings.io
-    name: JIWEN XIN
-    x-id: https://github.com/kevinxin90
+    email: william.baumgartner@cuanschutz.edu
+    name: Bill Baumgartner
+    x-id: https://github.com/bill-baumgartner/
     x-role: responsible developer
   description: Documentation of the Text Mining Targeted Association query web services.
   termsOfService: https://biothings.io/about

--- a/text_mining/smartapi.yaml
+++ b/text_mining/smartapi.yaml
@@ -19,7 +19,7 @@ info:
     version: 1.1.0
 servers:
 - description: TRAPI endpoint
-  url: https://smart-api.info/ui/978fe380a147a8641caf72320862697b
+  url: https://api.bte.ncats.io/v1/smartapi/978fe380a147a8641caf72320862697b
 - description: Encrypted Production server
   url: https://biothings.ncats.io/text_mining_targeted_association
 - description: Production server

--- a/text_mining/smartapi.yaml
+++ b/text_mining/smartapi.yaml
@@ -14,6 +14,9 @@ info:
     team:
       - Text Mining Provider
       - Service Provider
+    biolink-version: 1.5.0
+  x-trapi:
+    version: 1.1.0
 servers:
 - description: Encrypted Production server
   url: https://biothings.ncats.io/text_mining_targeted_association

--- a/text_mining/smartapi.yaml
+++ b/text_mining/smartapi.yaml
@@ -18,6 +18,8 @@ info:
   x-trapi:
     version: 1.1.0
 servers:
+- description: TRAPI endpoint
+  url: https://smart-api.info/ui/978fe380a147a8641caf72320862697b
 - description: Encrypted Production server
   url: https://biothings.ncats.io/text_mining_targeted_association
 - description: Production server

--- a/text_mining/smartapi.yaml
+++ b/text_mining/smartapi.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.0
 info:
   contact:
-    email: help@biothings.io
-    name: JIWEN XIN
-    x-id: https://github.com/kevinxin90
+    email: william.baumgartner@cuanschutz.edu
+    name: Bill Baumgartner
+    x-id: https://github.com/bill-baumgartner/
     x-role: responsible developer
   description: Documentation of the Text Mining Targeted Association query web services.
   termsOfService: https://biothings.io/about


### PR DESCRIPTION
This PR updates the Text Mining Provider registries to TRAPI v1.1. Registries for both the `text-mined assertion service` as well as the `concept cooccurrence service` have been updated. Changes include:

- updated contact information
- added `x-trapi` metadata field
- added `biolink-version` attribute to the `x-translator` metadata
  - Note: specification of 1.5.0 as the Biolink version is an estimate. It will be updated to a newer version of Biolink in an upcoming release.
- added TRAPI endpoint to the `server` metadata 

@newgene I think I've updated our registries appropriately. Please let me know if further changes are necessary. Thanks!