### PR TITLE
provenance update

### DIFF
--- a/DISEASES/smartapi.yaml
+++ b/DISEASES/smartapi.yaml
@@ -11,6 +11,7 @@ info:
   title: DISEASES API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-diseases"
     component: KP
     team:
       - Service Provider
@@ -212,8 +213,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/QueryPOSTResult"
           description: Query response objects with the "hits" property
-          x-bte-response-mapping:
-            "$ref": "#/components/x-bte-response-mapping/query-post"
         '400':
           content:
             application/json:
@@ -389,7 +388,7 @@ components:
       parameters:
         fields: DISEASES.associatedWith
       predicate: related_to
-      source: DISEASES
+      source: "infores:diseases"
       requestBody:
         body:
           q: "{inputs[0]}"
@@ -407,7 +406,7 @@ components:
       - id: SYMBOL
         semantic: Gene
       predicate: related_to
-      source: DISEASES
+      source: "infores:diseases"
       parameters:
         fields: DISEASES.doid
         size: '250'

--- a/EBIgene2phenotype/smartapi.yaml
+++ b/EBIgene2phenotype/smartapi.yaml
@@ -11,6 +11,7 @@ info:
   title: EBIgene2phenotype API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-ebi-gene2phenotype"
     component: KP
     team:
       - Service Provider
@@ -385,7 +386,7 @@ components:
       - id: HP
         semantic: PhenotypicFeature
       predicate: related_to
-      source: EBI
+      source: "infores:ebi-gene2phenotype"
       parameters:
         fields: gene2phenotype
       requestBody:
@@ -405,7 +406,7 @@ components:
       - id: HP
         semantic: PhenotypicFeature
       predicate: related_to
-      source: EBI
+      source: "infores:ebi-gene2phenotype"
       parameters:
         fields: _id
         size: '350'

--- a/LINCS/smartapi.yml
+++ b/LINCS/smartapi.yml
@@ -12,6 +12,7 @@ info:
     email: akoleti@med.miami.edu
     x-id: 'http://lincsportal.ccs.miami.edu/'
   x-translator:
+    infores-curie: "infores:lincs"
     component: KP
     team:
     - Service Provider
@@ -367,7 +368,7 @@ components:
       predicate: treats
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/drug-indication'
-      source: LINCS
+      source: "infores:lincs"  ## ...so weird duplicate source info happens here
       supportBatch: false
   x-bte-response-mapping:
     drug-indication:

--- a/MGIgene2phenotype/smartapi.yaml
+++ b/MGIgene2phenotype/smartapi.yaml
@@ -11,6 +11,7 @@ info:
   title: MGIgene2phenotype API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-mgi-g2p"
     component: KP
     team:
       - Service Provider
@@ -351,10 +352,11 @@ components:
       type: array
     QueryResult:
       properties:
-        hits:
-          items:
-            "$ref": "#/components/schemas/Chem"
-          type: array
+      ## to remove semantic error of missing reference
+        # hits:
+        #   items:
+        #     "$ref": "#/components/schemas/Chem"
+        #   type: array
         max_score:
           format: float
           type: number
@@ -389,7 +391,7 @@ components:
       parameters:
         fields: mgi.associated_with_disease
       predicate: related_to
-      source: mgi_gene2phenotype
+      source: "infores:mgi"
       requestBody:
         body:
           q: "{inputs[0]}"
@@ -407,7 +409,7 @@ components:
       - id: MP
         semantic: PhenotypicFeature
       predicate: related_to
-      source: mgi_gene2phenotype
+      source: "infores:mgi"
       parameters:
         fields: mgi.associated_with_phenotype
       requestBody:
@@ -430,7 +432,7 @@ components:
         fields: _id
         size: '300'
       predicate: related_to
-      source: mgi_gene2phenotype
+      source: "infores:mgi"
       requestBody:
         body:
           q: "{inputs[0]}"
@@ -448,7 +450,7 @@ components:
       - id: MP
         semantic: PhenotypicFeature
       predicate: related_to
-      source: mgi_gene2phenotype
+      source: "infores:mgi"
       parameters:
         fields: _id
         size: '300'

--- a/biolink/openapi.yml
+++ b/biolink/openapi.yml
@@ -10,6 +10,7 @@ info:
   title: BioLink API
   version: 1.0.1
   x-translator:
+    infores-curie: "infores:biolink-api"
     component: KP
     team:
     ## check what teams are involved
@@ -492,7 +493,7 @@ components:
       - id: HGNC
         semantic: Gene
       predicate: expresses
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/anatomy-gene-hgnc"
@@ -509,7 +510,7 @@ components:
       - id: HGNC
         semantic: Gene
       predicate: condition_associated_with_gene
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/disease-gene-hgnc"
@@ -526,7 +527,7 @@ components:
       - id: REACT
         semantic: Pathway
       predicate: related_to
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/disease-pathway"
@@ -543,7 +544,7 @@ components:
       - id: HP
         semantic: PhenotypicFeature
       predicate: has_phenotype
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/disease-phenotype"
@@ -560,7 +561,7 @@ components:
       - id: UBERON
         semantic: AnatomicalEntity
       predicate: expressed_in
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/gene-anatomy"
@@ -577,7 +578,7 @@ components:
       - id: MONDO
         semantic: Disease
       predicate: gene_associated_with_condition
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/gene-disease"
@@ -594,7 +595,7 @@ components:
       - id: HP
         semantic: PhenotypicFeature
       predicate: has_phenotype
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/gene-phenotype"
@@ -611,7 +612,7 @@ components:
       - id: HGNC
         semantic: Gene
       predicate: interacts_with
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/gene-interaction-hgnc"
@@ -628,7 +629,7 @@ components:
       - id: MONDO
         semantic: Disease
       predicate: related_to
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/pathway-disease"
@@ -645,7 +646,7 @@ components:
       - id: HP
         semantic: PhenotypicFeature
       predicate: related_to
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/pathway-phenotype"
@@ -662,7 +663,7 @@ components:
       - id: MONDO
         semantic: Disease
       predicate: phenotype_of
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/phenotype-disease"
@@ -679,7 +680,7 @@ components:
       - id: HGNC
         semantic: Gene
       predicate: condition_associated_with_gene
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/phenotype-gene-hgnc"
@@ -696,7 +697,7 @@ components:
       - id: REACT
         semantic: Pathway
       predicate: related_to
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/phenotype-pathway"
@@ -713,7 +714,7 @@ components:
       - id: DBSNP
         semantic: SequenceVariant
       predicate: phenotype_of
-      source: "Monarch Initiative"
+      source: "infores:monarchinitiative"
       supportBatch: false
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/phenotype-variant"

--- a/dgidb/openapi.yml
+++ b/dgidb/openapi.yml
@@ -10,6 +10,7 @@ info:
   title: BioThings DGIdb API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-dgidb"
     component: KP
     team:
       - Service Provider
@@ -431,7 +432,7 @@ components:
       predicate: physically_interacts_with
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/chemical-gene'
-      source: DGIdb
+      source: "infores:dgidb"
       supportBatch: false
       inputSeparator: ","
     gene-chemical:
@@ -452,7 +453,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/gene-chemical'
-      source: DGIdb
+      source: "infores:dgidb"
       supportBatch: true
       inputSeparator: ","
   x-bte-response-mapping:

--- a/drug_response_kp/smartapi.yaml
+++ b/drug_response_kp/smartapi.yaml
@@ -10,6 +10,7 @@ info:
   title: Drug Response KP API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-multiomics-drug-response"
     component: KP
     team:
       - Multiomics Provider
@@ -392,7 +393,8 @@ components:
       predicate: response_affected_by 
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/chemical-gene'
-      source: Multiomics Provider
+      ## note: source should be the source of data used
+      # source: Multiomics Provider
       supportBatch: false
     gene-chemical:
     - inputs:
@@ -410,7 +412,8 @@ components:
       predicate: affects_response_to 
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/gene-chemical'
-      source: Multiomics Provider
+      ## note: source should be the source of data used
+      # source: Multiomics Provider
       supportBatch: false
   x-bte-response-mapping:
     chemical-gene:

--- a/go_bp/smartapi.yaml
+++ b/go_bp/smartapi.yaml
@@ -10,6 +10,7 @@ info:
   title: Gene Ontology Biological Process API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-go-bp"
     component: KP
     team:
       - Service Provider
@@ -401,7 +402,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/has_subclass'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     subclass_of:
     - inputSeparator: ','
@@ -421,7 +422,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/subclass_of'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     negatively_regulates:
     - inputSeparator: ','
@@ -441,7 +442,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/negatively_regulates'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     positively_regulates:
     - inputSeparator: ','
@@ -461,7 +462,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/positively_regulates'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     regulates:
     - inputSeparator: ','
@@ -481,7 +482,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/regulates'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     negatively_regulated_by:
       - inputSeparator: ','
@@ -501,7 +502,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping:
           $ref: '#/components/x-bte-response-mapping/negatively_regulated_by'
-        source: Gene Ontology
+        source: "infores:go"
         supportBatch: true
     positively_regulated_by:
     - inputSeparator: ','
@@ -521,7 +522,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/positively_regulated_by'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     regulated_by:
     - inputSeparator: ','
@@ -541,7 +542,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/regulated_by'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     part_of:
     - inputSeparator: ','
@@ -561,7 +562,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/part_of'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     has_part:
     - inputSeparator: ','
@@ -581,7 +582,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/has_part'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
   x-bte-response-mapping:
     has_subclass:

--- a/go_mf/smartapi.yaml
+++ b/go_mf/smartapi.yaml
@@ -10,6 +10,7 @@ info:
   title: Gene Ontology Molecular Activity API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-go-mf"
     component: KP
     team:
       - Service Provider
@@ -395,7 +396,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/has_subclass'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     subclass_of:
     - inputSeparator: ','
@@ -415,7 +416,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/subclass_of'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     part_of:
     - inputSeparator: ','
@@ -435,7 +436,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/part_of'
-      source: Gene Ontology
+      source: "infores:go"
       supportBatch: true
     has_part:
       - inputSeparator: ','
@@ -455,7 +456,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping:
           $ref: '#/components/x-bte-response-mapping/has_part'
-        source: Gene Ontology
+        source: "infores:go"
         supportBatch: true
   x-bte-response-mapping:
     has_subclass:

--- a/hpo/smartapi.yaml
+++ b/hpo/smartapi.yaml
@@ -10,6 +10,7 @@ info:
   title: Human Phenotype Ontology API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-hpo"
     component: KP
     team:
       - Service Provider
@@ -391,7 +392,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/has_subclass'
-      source: Human Phenotype Ontology
+      source: "infores:hpo"
       supportBatch: true
     subclass_of:
     - inputSeparator: ','
@@ -411,7 +412,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/subclass_of'
-      source: Human Phenotype Ontology
+      source: "infores:hpo"
       supportBatch: true
   x-bte-response-mapping:
     has_subclass:

--- a/litvar/smartapi.yaml
+++ b/litvar/smartapi.yaml
@@ -12,6 +12,7 @@ info:
     name: Zhiyong Lu
     email: luzh@ncbi.nlm.nih.gov
   x-translator:
+    infores-curie: "infores:litvar"
     component: KP
     team:
       - Service Provider
@@ -49,7 +50,7 @@ components:
       - id: SYMBOL
         semantic: Gene
       predicate: is_sequence_variant_of
-      source: dbsnp
+      source: "infores:dbsnp"
       parameters:
         variantid: "{inputs[0]}%23%23"
       supportBatch: false

--- a/mychem.info/openapi_full.yml
+++ b/mychem.info/openapi_full.yml
@@ -11,6 +11,7 @@ info:
   title: MyChem.info API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:mychem-info"
     component: KP
     team:
       - Service Provider
@@ -416,6 +417,8 @@ components:
       DRUGBANK: drugbank.id
     chembl:
       CHEMBL.COMPOUND: chembl.molecule_chembl_id
+    drugcentral-chembl:
+      CHEMBL.COMPOUND: drugcentral.xrefs.chembl_id
     chembl-treats:
       MESH: chembl.drug_indications.mesh_id
       max_phase: chembl.drug_indications.max_phase_for_ind
@@ -438,7 +441,7 @@ components:
       ## biolink issue #677. Using a new predicate like has_substrate may be better
       ##   could use relation SIO:000905 "has substrate"
       predicate: metabolic_processing_affected_by
-      source: drugbank
+      source: "infores:drugbank"
       ## FYI: output format can also be uniprot ID
       outputs:
       - id: SYMBOL
@@ -465,7 +468,7 @@ components:
       ## biolink issue #677. Using a new predicate like has_target may be better
       ##   could use relation SIO:000291 ("has target")
       predicate: physically_interacts_with
-      source: drugbank
+      source: "infores:drugbank"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/target-drugbank"
     - supportBatch: true
@@ -475,7 +478,9 @@ components:
       requestBody:
         body:
           q: "{inputs[0]}"
-          scopes: chembl.molecule_chembl_id
+          ## there are 2382 records with drugcentral.bioactivity fields
+          ##   most of them (2362) also have the drugcentral.xrefs.chembl_id field
+          scopes: drugcentral.xrefs.chembl_id
         header: application/x-www-form-urlencoded
       inputs:
       - id: CHEMBL.COMPOUND
@@ -487,7 +492,7 @@ components:
       ## biolink issue #677. Using a new predicate like has_target may be better
       ##   could use relation SIO:000291 ("has target")
       predicate: physically_interacts_with
-      source: drugcentral
+      source: "infores:drugcentral"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/target-drugcentral"
     treats:
@@ -498,7 +503,10 @@ components:
       requestBody:
         body:
           q: "{inputs[0]}"
-          scopes: chembl.molecule_chembl_id
+          ## there are 2366 records with drugcentral.drug_use.indication fields
+          ##   most of them (2320) also have the drugcentral.xrefs.chembl_id field
+          ## note: there were slightly more records (2324) with the drugcentral.xrefs.unii field
+          scopes: drugcentral.xrefs.chembl_id
         header: application/x-www-form-urlencoded
       inputs:
       - id: CHEMBL.COMPOUND
@@ -508,7 +516,7 @@ components:
       - id: UMLS
         semantic: Disease
       predicate: treats
-      source: drugcentral
+      source: "infores:drugcentral"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/treats"
     contraindication:
@@ -519,7 +527,9 @@ components:
       requestBody:
         body:
           q: "{inputs[0]}"
-          scopes: chembl.molecule_chembl_id
+          ## there are 1375 records with drugcentral.drug_use.contraindication fields
+          ##   most of them (1365) also have the drugcentral.xrefs.chembl_id field
+          scopes: :drugcentral.xrefs.chembl_id
         header: application/x-www-form-urlencoded
       inputs:
       - id: CHEMBL.COMPOUND
@@ -529,7 +539,7 @@ components:
       - id: UMLS
         semantic: Disease
       predicate: contraindicated_for  ## current biolink predicate
-      source: drugcentral
+      source: "infores:drugcentral"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/contraindication"
     metabolize:
@@ -549,7 +559,7 @@ components:
       ## biolink issue #677. Using a new predicate like is_substrate_of may be better
       ##   could use relation DRUGBANK:Enzyme, DIDEO:00000041 "is substrate of", or NCIT:R122 "Chemical_Or_Drug_Is_Metabolized_By_Enzyme"
       predicate: affects_metabolic_processing_of
-      source: drugbank
+      source: "infores:drugbank"
       ## input could also be uniprot IDs (different scopes)
       inputs:
       - id: SYMBOL
@@ -577,13 +587,15 @@ components:
       ## biolink issue #677. Using a new predicate like targeted_by may be better
       ##   could use relation GENO:0000634 ("is_targeted_by")
       predicate: physically_interacts_with
-      source: drugbank
+      source: "infores:drugbank"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/drugbank"
     - supportBatch: true
       inputSeparator: ","
       parameters:
-        fields: chembl.molecule_chembl_id
+        ## there are 2382 records with drugcentral.bioactivity fields
+        ##   most of them (2362) also have the drugcentral.xrefs.chembl_id field
+        fields: drugcentral.xrefs.chembl_id
         size: '1000'
       requestBody:
         body:
@@ -600,14 +612,17 @@ components:
       ## biolink issue #677. Using a new predicate like targeted_by may be better
       ##   could use relation GENO:0000634 ("is_targeted_by")
       predicate: physically_interacts_with
-      source: drugcentral
+      source: "infores:drugcentral"
       response_mapping:
-        "$ref": "#/components/x-bte-response-mapping/chembl"
+        "$ref": "#/components/x-bte-response-mapping/drugcentral-chembl"
     treatedBy:
     - supportBatch: true
       inputSeparator: ","
       parameters:
-        fields: chembl.molecule_chembl_id
+        ## there are 2366 records with drugcentral.drug_use.indication fields
+        ##   most of them (2320) also have the drugcentral.xrefs.chembl_id field
+        ## note: there were slightly more records (2324) with the drugcentral.xrefs.unii field
+        fields: drugcentral.xrefs.chembl_id
         size: '1000'
       requestBody:
         body:
@@ -622,14 +637,16 @@ components:
       - id: UMLS
         semantic: Disease
       predicate: treated_by
-      source: drugcentral
+      source: "infores:drugcentral"
       response_mapping:
-        "$ref": "#/components/x-bte-response-mapping/chembl"
+        "$ref": "#/components/x-bte-response-mapping/drugcentral-chembl"
     contraindicatedBy:
     - supportBatch: true
       inputSeparator: ","
       parameters:
-        fields: chembl.molecule_chembl_id
+        ## there are 1375 records with drugcentral.drug_use.contraindication fields
+        ##   most of them (1365) also have the drugcentral.xrefs.chembl_id field
+        fields: drugcentral.xrefs.chembl_id
         size: '1000'
       requestBody:
         body:
@@ -644,9 +661,9 @@ components:
       - id: UMLS
         semantic: Disease
       predicate: has_contraindication
-      source: drugcentral
+      source: "infores:drugcentral"
       response_mapping:
-        "$ref": "#/components/x-bte-response-mapping/chembl"
+        "$ref": "#/components/x-bte-response-mapping/drugcentral-chembl"
     treats2:
     - supportBatch: true
       inputSeparator: ","
@@ -667,7 +684,7 @@ components:
         semantic: Disease
       ## Biolink PR to make this predicate, as an inverse of "contraindicated for"
       predicate: treats
-      source: chembl
+      source: "infores:chembl"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/chembl-treats"
     treated_by2:
@@ -690,6 +707,6 @@ components:
         semantic: Disease
       ## Biolink PR to make this predicate, as an inverse of "contraindicated for"
       predicate: treated_by
-      source: chembl
+      source: "infores:chembl"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/chembl"

--- a/mydisease.info/smartapi.yaml
+++ b/mydisease.info/smartapi.yaml
@@ -6,6 +6,7 @@ info:
     x-id: https://github.com/newgene
     x-role: responsible developer
   x-translator:
+    infores-curie: "infores:mydisease-info"
     component: KP
     team:
       - Service Provider
@@ -442,7 +443,7 @@ components:
       requestBody:
         body:
           q: "{inputs[0]}"  ## example: put C0024776 here
-          scopes: mondo.xrefs.umls, disgenet.xrefs.umls
+          scopes: disgenet.xrefs.umls
         header: application/x-www-form-urlencoded
       inputs:
       - id: UMLS
@@ -451,7 +452,7 @@ components:
       - id: NCBIGene
         semantic: Gene
       predicate: related_to
-      source: DisGeNET
+      source: "infores:disgenet"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/disease-gene"
     disease-variant:
@@ -462,7 +463,7 @@ components:
       requestBody:
         body:
           q: "{inputs[0]}"   ## example: put C0024776 here
-          scopes: mondo.xrefs.umls, disgenet.xrefs.umls
+          scopes: disgenet.xrefs.umls
         header: application/x-www-form-urlencoded
       inputs:
       - id: UMLS
@@ -471,7 +472,7 @@ components:
       - id: DBSNP
         semantic: SequenceVariant
       predicate: related_to
-      source: DisGeNET
+      source: "infores:disgenet"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/disease-variant"
     disease-phenotype:
@@ -491,7 +492,7 @@ components:
       - id: HP
         semantic: PhenotypicFeature
       predicate: has_phenotype
-      source: HPO Annotations
+      source: "infores:hpo-annotations"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/disease-phenotype"
     disease-phenotype2:
@@ -511,7 +512,7 @@ components:
       - id: HP
         semantic: PhenotypicFeature
       predicate: has_phenotype
-      source: HPO Annotations
+      source: "infores:hpo-annotations"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/disease-phenotype"
     disease-phenotype3:  ## covid only
@@ -531,7 +532,7 @@ components:
       - id: HP
         semantic: PhenotypicFeature
       predicate: has_phenotype
-      source: Automat covid_phenotypes
+      source: "infores:automat-covid-phenotypes"   ## but an older downloaded version...
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/disease-phenotype2"
     disease-chemical:
@@ -553,7 +554,7 @@ components:
       - id: MESH
         semantic: ChemicalSubstance
       predicate: related_to
-      source: CTD
+      source: "infores:ctd"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/disease-chemical"
     disease-chemical2:
@@ -575,7 +576,7 @@ components:
       - id: MESH
         semantic: ChemicalSubstance
       predicate: related_to
-      source: CTD
+      source: "infores:ctd"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/disease-chemical"        
 #     disease-pathway:  ## input is MESH Disease, example: put C536029 here
@@ -596,7 +597,7 @@ components:
 #       - id: REACT
 #         semantic: Pathway      
 #       predicate: related_to
-#       source: CTD
+#       source: "infores:ctd"
 #       response_mapping:
 #         "$ref": "#/components/x-bte-response-mapping/disease-pathway" 
 #     ## output is KEGG pathway ID
@@ -616,7 +617,7 @@ components:
 #       - id: KEGG
 #         semantic: Pathway      
 #       predicate: related_to
-#       source: CTD
+#       source: "infores:ctd"
 #       response_mapping:
 #         "$ref": "#/components/x-bte-response-mapping/disease-pathway2"           
 #     disease-pathway2:  ## input is OMIM Disease, example: put 261515 here
@@ -637,7 +638,7 @@ components:
 #       - id: REACT
 #         semantic: Pathway      
 #       predicate: related_to
-#       source: CTD
+#       source: "infores:ctd"
 #       response_mapping:
 #         "$ref": "#/components/x-bte-response-mapping/disease-pathway" 
 #     ## output is KEGG pathway ID
@@ -657,7 +658,7 @@ components:
 #       - id: KEGG
 #         semantic: Pathway      
 #       predicate: related_to
-#       source: CTD
+#       source: "infores:ctd"
 #       response_mapping:
 #         "$ref": "#/components/x-bte-response-mapping/disease-pathway2"    
     gene-disease:
@@ -679,7 +680,7 @@ components:
       - id: UMLS
         semantic: Disease
       predicate: related_to
-      source: DisGeNET
+      source: "infores:disgenet"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/umls"
     variant-disease:
@@ -701,7 +702,7 @@ components:
       - id: UMLS
         semantic: Disease
       predicate: related_to
-      source: DisGeNET
+      source: "infores:disgenet"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/umls"
     phenotype-disease:
@@ -725,7 +726,7 @@ components:
       - id: OMIM
         semantic: Disease
       predicate: phenotype_of
-      source: HPO Annotations
+      source: "infores:hpo-annotations"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/omim"
     phenotype-disease2:
@@ -749,7 +750,7 @@ components:
       - id: ORPHANET
         semantic: Disease
       predicate: phenotype_of
-      source: HPO Annotations
+      source: "infores:hpo-annotations"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/orphanet"
     phenotype-disease3:  ## covid only
@@ -771,7 +772,7 @@ components:
       - id: MONDO
         semantic: Disease
       predicate: phenotype_of
-      source: Automat covid_phenotypes
+      source: "infores:automat-covid-phenotypes"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/mondo"
     chemical-disease:
@@ -795,7 +796,7 @@ components:
       - id: MESH
         semantic: Disease
       predicate: related_to
-      source: CTD
+      source: "infores:ctd"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/ctd-mesh-disease"
     chemical-disease2:
@@ -819,7 +820,7 @@ components:
       - id: OMIM
         semantic: Disease
       predicate: related_to
-      source: CTD
+      source: "infores:ctd"
       response_mapping: 
         "$ref": "#/components/x-bte-response-mapping/ctd-omim-disease"  
 #     pathway-disease:  ## input is REACT pathway ID, example: put R-HSA-1280218 or R-HSA-5619084 here  
@@ -842,7 +843,7 @@ components:
 #       - id: MESH
 #         semantic: Disease
 #       predicate: related_to
-#       source: CTD
+#       source: "infores:ctd"
 #       response_mapping:
 #         "$ref": "#/components/x-bte-response-mapping/ctd-mesh-disease"
 #     ## output is OMIM Disease
@@ -864,7 +865,7 @@ components:
 #       - id: OMIM
 #         semantic: Disease
 #       predicate: related_to
-#       source: CTD
+#       source: "infores:ctd"
 #       response_mapping:
 #         "$ref": "#/components/x-bte-response-mapping/ctd-omim-disease" 
 #     pathway-disease2:  ## input is KEGG pathway ID, example: put hsa04360 or hsa00230 here  
@@ -887,7 +888,7 @@ components:
 #       - id: MESH
 #         semantic: Disease
 #       predicate: related_to
-#       source: CTD
+#       source: "infores:ctd"
 #       response_mapping:
 #         "$ref": "#/components/x-bte-response-mapping/ctd-mesh-disease"
 #     ## output is OMIM Disease
@@ -909,7 +910,7 @@ components:
 #       - id: OMIM
 #         semantic: Disease
 #       predicate: related_to
-#       source: CTD
+#       source: "infores:ctd"
 #       response_mapping:
 #         "$ref": "#/components/x-bte-response-mapping/ctd-omim-disease"
     has_subclass:
@@ -933,7 +934,7 @@ components:
       - id: MONDO
         semantic: Disease
       predicate: superclass_of  ## this is the inverse of subclass_of right now
-      source: MONDO
+      source: "infores:mondo"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/has_subclass"
     subclass_of:
@@ -957,6 +958,6 @@ components:
       - id: MONDO
         semantic: Disease
       predicate: subclass_of
-      source: MONDO
+      source: "infores:mondo"
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/subclass_of"

--- a/mygene.info/openapi_full.yml
+++ b/mygene.info/openapi_full.yml
@@ -232,6 +232,7 @@ components:
             id: NCBIGene
             semantic: Gene
         parameters: 
+          ## all records with pathway.reactome.id field also have entrezgene field
           fields: entrezgene
           species: human
         predicate: has_participant
@@ -243,7 +244,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/entrezgene"
-        source: Reactome
+        source: "infores:reactome"
         supportBatch: true
       - 
         inputSeparator: ","
@@ -257,6 +258,7 @@ components:
             id: NCBIGene
             semantic: Gene
         parameters: 
+          ## all records with pathway.kegg field also have entrezgene field
           fields: entrezgene
           species: human
         predicate: has_participant
@@ -268,8 +270,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/entrezgene"
-        ## don't abbreviate since multiple resources named "CPDB"
-        source: ConsensusPathDB
+        source: "infores:cpdb"   ## ConsensusPathDB
         supportBatch: true
       - 
         inputSeparator: ","
@@ -283,6 +284,7 @@ components:
             id: NCBIGene
             semantic: Gene
         parameters: 
+          ## all records with pathway.wikipathways field also have entrezgene field
           fields: entrezgene
           species: human
         predicate: has_participant
@@ -294,8 +296,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/entrezgene"
-        ## don't abbreviate since multiple resources named "CPDB"
-        source: ConsensusPathDB
+        source: "infores:cpdb"   ## ConsensusPathDB
         supportBatch: true
       - 
         inputSeparator: ","
@@ -309,6 +310,7 @@ components:
             id: NCBIGene
             semantic: Gene
         parameters: 
+          ## all records with pathway.biocarta field also have entrezgene field
           fields: entrezgene
           species: human
         predicate: has_participant
@@ -320,10 +322,8 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/entrezgene"
-        ## don't abbreviate since multiple resources named "CPDB"
-        source: ConsensusPathDB
+        source: "infores:cpdb"   ## ConsensusPathDB
         supportBatch: true
-      
     enablesMF:
     ## biolink: weird predicate. biolink doesn't have something like has_activity/has_function 
     ## future: relation could be RO:0000085 (has_function), but this currently isn't mapped to biolink
@@ -344,11 +344,12 @@ components:
         requestBody: 
           body: 
             q: "{inputs[0]}"
+            ## all records with go.MF field also have entrezgene field
             scopes: entrezgene
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/molecularFunction"
-        source: "NCBI Gene"
+        source: "infores:ncbi-gene"   ## which got from GO Annotations...
         supportBatch: true
     MFToGene:
     ## biolink: weird predicate. biolink doesn't have something like activity_of/function_of 
@@ -364,6 +365,7 @@ components:
             id: NCBIGene
             semantic: Gene
         parameters: 
+          ## all records with go.MF field also have entrezgene field
           fields: entrezgene
           species: human
         predicate: enabled_by
@@ -375,7 +377,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/entrezgene"
-        source: "NCBI Gene"
+        source: "infores:ncbi-gene"   ## which got from GO Annotations...
         supportBatch: true
     GeneToProtein: 
     ## future: relation could be RO:0002205 (has_gene_product), currently mapped to biolink:has_gene_product
@@ -391,6 +393,8 @@ components:
             semantic: Protein
         parameters: 
           fields: uniprot.Swiss-Prot
+          ## there are >107,000 records with both uniprot and ensembl.gene fields 
+          ##   (vs >244,000 records with only uniprot fields)
           species: human
         predicate: has_gene_product
         requestBody: 
@@ -401,7 +405,7 @@ components:
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/uniprotProtein"
         ## specifically from the ID mapping file https://www.uniprot.org/downloads#uniprotkblink
-        source: UniprotKB
+        source: "infores:uniprot"
         supportBatch: true
     ProteinToGene: 
     ## relation: use RO:0002204 (gene_product_of)
@@ -417,6 +421,8 @@ components:
             semantic: Gene
         parameters: 
           fields: ensembl.gene
+          ## there are >107,000 records with both uniprot and ensembl.gene fields 
+          ##   (vs >244,000 records with only uniprot fields)
           species: human
         predicate: gene_product_of
         requestBody: 
@@ -427,7 +433,7 @@ components:
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/ensemblGene"
         ## specifically from the ID mapping file https://www.uniprot.org/downloads#uniprotkblink
-        source: UniprotKB
+        source: "infores:uniprot"
         supportBatch: true
     ## pantherdb gives orthologs and paralogs, which are both homologs. Hence we use homolog
     ## currently written: MGI, RGD, ZFIN, WormBase, SGD, dictyBase, POMBASE
@@ -446,6 +452,8 @@ components:
             semantic: Gene
         parameters: 
           fields: pantherdb.ortholog
+          ## almost all records with pantherdb.ortholog fields also have the entrezgene field
+          ##   > 145,000 records have both fields, vs ~ 3600 records don't have the entrezgene field
         predicate: homologous_to
         requestBody: 
           body: 
@@ -454,7 +462,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/pantherMGI"
-        source: PANTHER
+        source: "infores:panther"
         supportBatch: true
 #       - 
 #         inputSeparator: ","
@@ -476,7 +484,7 @@ components:
 #           header: application/x-www-form-urlencoded
 #         response_mapping: 
 #           $ref: "#/components/x-bte-response-mapping/pantherRGD"
-#         source: PANTHER
+#         source: "infores:panther"
 #         supportBatch: true
 #       - 
 #         inputSeparator: ","
@@ -498,7 +506,7 @@ components:
 #           header: application/x-www-form-urlencoded
 #         response_mapping: 
 #           $ref: "#/components/x-bte-response-mapping/pantherZFIN"
-#         source: PANTHER
+#         source: "infores:panther"
 #         supportBatch: true
 #       - 
 #         inputSeparator: ","
@@ -520,7 +528,7 @@ components:
 #           header: application/x-www-form-urlencoded
 #         response_mapping: 
 #           $ref: "#/components/x-bte-response-mapping/pantherWorm"
-#         source: PANTHER
+#         source: "infores:panther"
 #         supportBatch: true
 #       - 
 #         inputSeparator: ","
@@ -542,7 +550,7 @@ components:
 #           header: application/x-www-form-urlencoded
 #         response_mapping: 
 #           $ref: "#/components/x-bte-response-mapping/pantherSGD"
-#         source: PANTHER
+#         source: "infores:panther"
 #         supportBatch: true
 #       - 
 #         inputSeparator: ","
@@ -564,7 +572,7 @@ components:
 #           header: application/x-www-form-urlencoded
 #         response_mapping: 
 #           $ref: "#/components/x-bte-response-mapping/pantherDicty"
-#         source: PANTHER
+#         source: "infores:panther"
 #         supportBatch: true
 #       - 
 #         inputSeparator: ","
@@ -586,7 +594,7 @@ components:
 #           header: application/x-www-form-urlencoded
 #         response_mapping: 
 #           $ref: "#/components/x-bte-response-mapping/pantherPom"
-#         source: PANTHER
+#         source: "infores:panther"
 #         supportBatch: true
     hasTranscript: 
     ## future: relation could be RO:0002511 (transcribed_to)
@@ -611,7 +619,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/ensemblTranscript"
-        source: Ensembl
+        source: "infores:ensembl-gene"  ## ensembl or specifically ensembl-gene?
         supportBatch: true
     involvedInBP:
     ## biolink: confusing. biolink currently doesn't have involved_in; this could also be contributes_to?
@@ -627,6 +635,7 @@ components:
             id: GO
             semantic: BiologicalProcess
         parameters: 
+          ## all records with go.BP field also have entrezgene field
           fields: go.BP
           species: human
         predicate: participates_in
@@ -637,7 +646,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/biologicalProcess"
-        source: "NCBI Gene"
+        source: "infores:ncbi-gene"   ## which got from GO Annotations...
         supportBatch: true
     BPToGene: 
     ## biolink: confusing, hard to find inverse for
@@ -653,6 +662,7 @@ components:
             id: NCBIGene
             semantic: Gene
         parameters: 
+          ## all records with go.BP field also have entrezgene field
           fields: entrezgene
           species: human
         predicate: has_participant
@@ -664,7 +674,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/entrezgene"
-        source: "NCBI Gene"
+        source: "infores:ncbi-gene"   ## which got from GO Annotations...
         supportBatch: true
     involvedInCC: 
     ## biolink: confusing, since it's a gene whose activity takes place in the cellular component (complex or organelle) - not a direct biological relationship
@@ -681,6 +691,7 @@ components:
             id: GO
             semantic: CellularComponent
         parameters: 
+          ## all records with go.CC field also have entrezgene field
           fields: go.CC
           species: human
         predicate: expressed_in
@@ -691,7 +702,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/cellularComponent"
-        source: "NCBI Gene"
+        source: "infores:ncbi-gene"   ## which got from GO Annotations...
         supportBatch: true
     CCToGene: 
     ## biolink: confusing, since it's a gene whose activity takes place in the cellular component (complex or organelle) - not a direct biological relationship
@@ -708,6 +719,7 @@ components:
             id: NCBIGene
             semantic: Gene
         parameters: 
+          ## all records with go.CC field also have entrezgene field
           fields: entrezgene
           species: human
         predicate: expresses
@@ -719,7 +731,7 @@ components:
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/entrezgene"
-        source: "NCBI Gene"
+        source: "infores:ncbi-gene"   ## which got from GO Annotations...
         supportBatch: true
     involvedInPathway:    ## using Reactome, KEGG, Wikipathways
     ## future: use relation "NCIT:gene_is_element_in_pathway" or RO:0000056 (participates in), both mapped to biolink:participates_in
@@ -741,11 +753,12 @@ components:
         requestBody: 
           body: 
             q: "{inputs[0]}"
+            ## all records with pathway.reactome.id field also have entrezgene field
             scopes: entrezgene
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/reactomePathway"
-        source: Reactome
+        source: "infores:reactome"
         supportBatch: true
       - 
         inputSeparator: ","
@@ -765,11 +778,12 @@ components:
         requestBody: 
           body: 
             q: "{inputs[0]}"
+            ## all records with pathway.kegg field also have entrezgene field
             scopes: entrezgene
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/keggPathway"
-        source: ConsensusPathDB
+        source: "infores:cpdb"   ## ConsensusPathDB
         supportBatch: true
       - 
         inputSeparator: ","
@@ -789,11 +803,12 @@ components:
         requestBody: 
           body: 
             q: "{inputs[0]}"
+            ## all records with pathway.wikipathways field also have entrezgene field
             scopes: entrezgene
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/wikipathway"
-        source: ConsensusPathDB
+        source: "infores:cpdb"   ## ConsensusPathDB
         supportBatch: true
       - 
         inputSeparator: ","
@@ -813,11 +828,12 @@ components:
         requestBody: 
           body: 
             q: "{inputs[0]}"
+            ## all records with pathway.biocarta field also have entrezgene field
             scopes: entrezgene
           header: application/x-www-form-urlencoded
         response_mapping: 
           $ref: "#/components/x-bte-response-mapping/biocarta"
-        source: ConsensusPathDB
+        source: "infores:cpdb"   ## ConsensusPathDB
         supportBatch: true
   x-bte-response-mapping: 
 #     ENSEMBL: ensembl.gene
@@ -906,6 +922,7 @@ info:
   title: "MyGene.info API"
   version: "3.0"
   x-translator: 
+    infores-curie: "infores:mygene-info"
     component: KP
     team: 
       - "Service Provider"

--- a/myvariant.info/openapi_full.yml
+++ b/myvariant.info/openapi_full.yml
@@ -11,6 +11,7 @@ info:
   title: MyVariant.info API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:myvariant-info"
     component: KP
     team:
       - Service Provider
@@ -369,7 +370,7 @@ components:
       parameters:
         fields: dbsnp.gene.geneid
       predicate: is_sequence_variant_of
-      source: dbsnp
+      source: "infores:dbsnp"
       requestBody:
         body:
           q: "{inputs[0]}"
@@ -387,12 +388,14 @@ components:
     - supportBatch: true
       inputSeparator: ","
       parameters:
+        ## maybe use clinvar variant ID (clinvar.variant_id) or allele ID (clinvar.allele_id) instead 
         fields: clinvar.rcv
       predicate: related_to
-      source: clinvar
+      source: "infores:clinvar"
       requestBody:
         body:
           q: "{inputs[0]}"
+          ## out of > 862,000 records with clinvar.rcv field, >695,000 records also have dbsnp.rsid
           scopes: dbsnp.rsid
         header: application/x-www-form-urlencoded
       inputs:
@@ -407,10 +410,11 @@ components:
     - supportBatch: true
       inputSeparator: ","
       parameters:
+        ## out of > 862,000 records with clinvar.rcv field, >695,000 records also have dbsnp.rsid
         fields: dbsnp.rsid
         size: '250'
       predicate: related_to
-      source: clinvar
+      source: "infores:clinvar"
       requestBody:
         body:
           q: "{inputs[0]}"
@@ -428,10 +432,13 @@ components:
       - supportBatch: true
         inputSeparator: ","
         parameters:
+          ## any way to improve retrieval of info with a variant ID?
+          ## out of 2648 records with civic.evidence_items field, 653 records also have dbsnp.rsid
+          ## note that some records' _id field is the CIVIC variant ID (not MYVARIANT_HG19)
           fields: civic.evidence_items
           size: '1000'
         predicate: affects_response_to
-        source: civic
+        source: "infores:civic"
         requestBody:
           body:
             q: "{inputs[0]}"

--- a/ols/smartapi.yaml
+++ b/ols/smartapi.yaml
@@ -13,6 +13,7 @@ info:
     x-role: responsible developer
     email: help@pharmgkb.org
   x-translator:
+    infores-curie: "infores:ols"
     component: KP
     team:
       - Service Provider
@@ -46,7 +47,7 @@ components:
       - id: DOID
         semantic: Disease
       predicate: superclass_of  ## this is current biolink, same meaning as "has_subclass"
-      source: DO  ## follows same format as mydisease.info MONDO-based operations
+      source: "infores:disease-ontology"
       outputs:
       - id: DOID
         semantic: Disease

--- a/opentarget/smartapi.yaml
+++ b/opentarget/smartapi.yaml
@@ -9,6 +9,7 @@ info:
     x-role: responsible developer
     email: help@opentarget.org
   x-translator:
+    infores-curie: "infores:open-target"
     component: KP
     team:
       - Service Provider
@@ -63,7 +64,7 @@ components:
       - id: CHEMBL.COMPOUND
         semantic: ChemicalSubstance
       predicate: related_to
-      source: CHEMBL
+      source: "infores:chembl"
       parameters:
         target: "{inputs[0]}"
         datasource: chembl

--- a/quickgo/smartapi.yaml
+++ b/quickgo/smartapi.yaml
@@ -14,6 +14,7 @@ info:
     x-role: responsible developer
     email: help@pharmgkb.org
   x-translator:
+    infores-curie: "infores:ebi-quick-go"
     component: KP
     team:
       - Service Provider
@@ -46,7 +47,7 @@ components:
     - inputs:
       - id: GO
         semantic: MolecularActivity
-      source: Gene Ontology
+      source: "infores:go"
       predicate: superclass_of  ## this is current biolink, same meaning as "has_subclass"
       outputs:
       - id: GO

--- a/semmed/semmed_anatomy.yaml
+++ b/semmed/semmed_anatomy.yaml
@@ -12,6 +12,7 @@ info:
   title: SEMMED Anatomy API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-semmeddb-anatomy"
     component: KP
     team:
       - Service Provider
@@ -417,7 +418,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -438,7 +439,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -459,7 +460,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -480,7 +481,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -501,7 +502,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -522,7 +523,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -543,7 +544,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -564,7 +565,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -585,7 +586,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -606,7 +607,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -627,7 +628,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -648,7 +649,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -669,7 +670,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -690,7 +691,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -711,7 +712,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -732,7 +733,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -753,7 +754,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -774,7 +775,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -795,7 +796,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -816,7 +817,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -837,7 +838,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -858,7 +859,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -879,7 +880,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -900,7 +901,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -921,7 +922,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -942,7 +943,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -963,7 +964,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -984,7 +985,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1005,7 +1006,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1026,7 +1027,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1047,7 +1048,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1068,7 +1069,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1089,7 +1090,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1110,7 +1111,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1131,7 +1132,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1152,7 +1153,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1173,7 +1174,7 @@ components:
       - id: UMLS
         semantic: AnatomicalEntity
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent

--- a/semmed/semmed_biological_process.yaml
+++ b/semmed/semmed_biological_process.yaml
@@ -12,6 +12,7 @@ info:
   title: SEMMED Biological Process API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-semmeddb-biological-process"
     component: KP
     team:
       - Service Provider
@@ -447,7 +448,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -468,7 +469,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -489,7 +490,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -510,7 +511,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -531,7 +532,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -552,7 +553,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -573,7 +574,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -594,7 +595,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -615,7 +616,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -636,7 +637,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -657,7 +658,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -678,7 +679,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -699,7 +700,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -720,7 +721,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -741,7 +742,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -762,7 +763,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -783,7 +784,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -804,7 +805,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -825,7 +826,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -846,7 +847,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -867,7 +868,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -888,7 +889,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -909,7 +910,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -930,7 +931,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -951,7 +952,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -972,7 +973,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -993,7 +994,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1014,7 +1015,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1035,7 +1036,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1056,7 +1057,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1077,7 +1078,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1098,7 +1099,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1119,7 +1120,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1140,7 +1141,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1161,7 +1162,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1182,7 +1183,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1203,7 +1204,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1224,7 +1225,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1245,7 +1246,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1266,7 +1267,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1287,7 +1288,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1308,7 +1309,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1329,7 +1330,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1350,7 +1351,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1371,7 +1372,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1392,7 +1393,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1413,7 +1414,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1434,7 +1435,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1455,7 +1456,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1476,7 +1477,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1497,7 +1498,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1518,7 +1519,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1539,7 +1540,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1560,7 +1561,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1581,7 +1582,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1602,7 +1603,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1623,7 +1624,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1644,7 +1645,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1665,7 +1666,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1686,7 +1687,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1707,7 +1708,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1728,7 +1729,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1749,7 +1750,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1770,7 +1771,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1791,7 +1792,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1812,7 +1813,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1833,7 +1834,7 @@ components:
       - id: UMLS
         semantic: BiologicalProcess
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease

--- a/semmed/semmed_chemical.yaml
+++ b/semmed/semmed_chemical.yaml
@@ -12,6 +12,7 @@ info:
   title: SEMMED Chemical API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-semmeddb-chemical"
     component: KP
     team:
       - Service Provider
@@ -473,7 +474,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -494,7 +495,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -515,7 +516,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -536,7 +537,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -557,7 +558,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -578,7 +579,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -599,7 +600,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -620,7 +621,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -641,7 +642,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -662,7 +663,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -683,7 +684,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -704,7 +705,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -725,7 +726,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -746,7 +747,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -767,7 +768,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -788,7 +789,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -809,7 +810,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -830,7 +831,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -851,7 +852,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -872,7 +873,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -893,7 +894,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -914,7 +915,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -935,7 +936,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -956,7 +957,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -977,7 +978,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -998,7 +999,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1019,7 +1020,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1040,7 +1041,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1061,7 +1062,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1082,7 +1083,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1103,7 +1104,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1124,7 +1125,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1145,7 +1146,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1166,7 +1167,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1187,7 +1188,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1208,7 +1209,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1229,7 +1230,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1250,7 +1251,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1271,7 +1272,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1292,7 +1293,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1313,7 +1314,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1334,7 +1335,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1355,7 +1356,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1376,7 +1377,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1397,7 +1398,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1418,7 +1419,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1439,7 +1440,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1460,7 +1461,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1481,7 +1482,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1502,7 +1503,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1523,7 +1524,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1544,7 +1545,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1565,7 +1566,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1586,7 +1587,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1607,7 +1608,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1628,7 +1629,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1649,7 +1650,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1670,7 +1671,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1691,7 +1692,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1712,7 +1713,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1733,7 +1734,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1754,7 +1755,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1775,7 +1776,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1796,7 +1797,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1817,7 +1818,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1838,7 +1839,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1859,7 +1860,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1880,7 +1881,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1901,7 +1902,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1922,7 +1923,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1943,7 +1944,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1964,7 +1965,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1985,7 +1986,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -2006,7 +2007,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -2027,7 +2028,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -2048,7 +2049,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -2069,7 +2070,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -2090,7 +2091,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -2111,7 +2112,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -2132,7 +2133,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -2153,7 +2154,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -2174,7 +2175,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -2195,7 +2196,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -2216,7 +2217,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -2237,7 +2238,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -2258,7 +2259,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -2279,7 +2280,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -2300,7 +2301,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -2321,7 +2322,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -2342,7 +2343,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -2363,7 +2364,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -2384,7 +2385,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -2405,7 +2406,7 @@ components:
       - id: UMLS
         semantic: ChemicalSubstance
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease

--- a/semmed/semmed_disease.yaml
+++ b/semmed/semmed_disease.yaml
@@ -12,6 +12,7 @@ info:
   title: SEMMED Disease API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-semmeddb-disease"
     component: KP
     team:
       - Service Provider
@@ -476,7 +477,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -497,7 +498,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -518,7 +519,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -539,7 +540,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -560,7 +561,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -581,7 +582,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -602,7 +603,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -623,7 +624,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -644,7 +645,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -665,7 +666,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -686,7 +687,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -707,7 +708,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -728,7 +729,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -749,7 +750,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -770,7 +771,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -791,7 +792,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -812,7 +813,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -833,7 +834,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -854,7 +855,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -875,7 +876,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -896,7 +897,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -917,7 +918,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -938,7 +939,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -959,7 +960,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -980,7 +981,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1001,7 +1002,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1022,7 +1023,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1043,7 +1044,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1064,7 +1065,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1085,7 +1086,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1106,7 +1107,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1127,7 +1128,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1148,7 +1149,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1169,7 +1170,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1190,7 +1191,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1211,7 +1212,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1232,7 +1233,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1253,7 +1254,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1274,7 +1275,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1295,7 +1296,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1316,7 +1317,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1337,7 +1338,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1358,7 +1359,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1379,7 +1380,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1400,7 +1401,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1421,7 +1422,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1442,7 +1443,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1463,7 +1464,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1484,7 +1485,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1505,7 +1506,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1526,7 +1527,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1547,7 +1548,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1568,7 +1569,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1589,7 +1590,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1610,7 +1611,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1631,7 +1632,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1652,7 +1653,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1673,7 +1674,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1694,7 +1695,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1715,7 +1716,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1736,7 +1737,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1757,7 +1758,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1778,7 +1779,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1799,7 +1800,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1820,7 +1821,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1841,7 +1842,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1862,7 +1863,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1883,7 +1884,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1904,7 +1905,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1925,7 +1926,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1946,7 +1947,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1967,7 +1968,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1988,7 +1989,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -2009,7 +2010,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -2030,7 +2031,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -2051,7 +2052,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -2072,7 +2073,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -2093,7 +2094,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -2114,7 +2115,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -2135,7 +2136,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -2156,7 +2157,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -2177,7 +2178,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -2198,7 +2199,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -2219,7 +2220,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -2240,7 +2241,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -2261,7 +2262,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -2282,7 +2283,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -2303,7 +2304,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -2324,7 +2325,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -2345,7 +2346,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -2366,7 +2367,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -2387,7 +2388,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -2408,7 +2409,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -2429,7 +2430,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -2450,7 +2451,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -2471,7 +2472,7 @@ components:
       - id: UMLS
         semantic: Disease
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease

--- a/semmed/semmed_gene.yaml
+++ b/semmed/semmed_gene.yaml
@@ -12,6 +12,7 @@ info:
   title: SEMMED Gene API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-semmeddb-gene"
     component: KP
     team:
       - Service Provider
@@ -454,7 +455,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -475,7 +476,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -496,7 +497,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -517,7 +518,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -538,7 +539,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -559,7 +560,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -580,7 +581,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -601,7 +602,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -622,7 +623,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -643,7 +644,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -664,7 +665,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -685,7 +686,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -706,7 +707,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -727,7 +728,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -748,7 +749,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -769,7 +770,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -790,7 +791,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -811,7 +812,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -832,7 +833,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -853,7 +854,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -874,7 +875,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -895,7 +896,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -916,7 +917,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -937,7 +938,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -958,7 +959,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -979,7 +980,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1000,7 +1001,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1021,7 +1022,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1042,7 +1043,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1063,7 +1064,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1084,7 +1085,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1105,7 +1106,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1126,7 +1127,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1147,7 +1148,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1168,7 +1169,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1189,7 +1190,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1210,7 +1211,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1231,7 +1232,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1252,7 +1253,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1273,7 +1274,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1294,7 +1295,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1315,7 +1316,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1336,7 +1337,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1357,7 +1358,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1378,7 +1379,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1399,7 +1400,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1420,7 +1421,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1441,7 +1442,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1462,7 +1463,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1483,7 +1484,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1504,7 +1505,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1525,7 +1526,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1546,7 +1547,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1567,7 +1568,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1588,7 +1589,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1609,7 +1610,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1630,7 +1631,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1651,7 +1652,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1672,7 +1673,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1693,7 +1694,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1714,7 +1715,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1735,7 +1736,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1756,7 +1757,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1777,7 +1778,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1798,7 +1799,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1819,7 +1820,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1840,7 +1841,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1861,7 +1862,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1882,7 +1883,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1903,7 +1904,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1924,7 +1925,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1945,7 +1946,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1966,7 +1967,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1987,7 +1988,7 @@ components:
       - id: UMLS
         semantic: Gene
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease

--- a/semmed/semmed_phenotype.yaml
+++ b/semmed/semmed_phenotype.yaml
@@ -12,6 +12,7 @@ info:
   title: SEMMED Phenotype API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-semmeddb-phenotype"
     component: KP
     team:
       - Service Provider
@@ -453,7 +454,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -474,7 +475,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -495,7 +496,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -516,7 +517,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -537,7 +538,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -558,7 +559,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -579,7 +580,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -600,7 +601,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -621,7 +622,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -642,7 +643,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -663,7 +664,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -684,7 +685,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -705,7 +706,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -726,7 +727,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -747,7 +748,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -768,7 +769,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -789,7 +790,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -810,7 +811,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -831,7 +832,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -852,7 +853,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -873,7 +874,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -894,7 +895,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -915,7 +916,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -936,7 +937,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -957,7 +958,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -978,7 +979,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -999,7 +1000,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1020,7 +1021,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1041,7 +1042,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1062,7 +1063,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1083,7 +1084,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1104,7 +1105,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1125,7 +1126,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1146,7 +1147,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1167,7 +1168,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1188,7 +1189,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1209,7 +1210,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1230,7 +1231,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1251,7 +1252,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1272,7 +1273,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1293,7 +1294,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1314,7 +1315,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1335,7 +1336,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1356,7 +1357,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1377,7 +1378,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1398,7 +1399,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1419,7 +1420,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1440,7 +1441,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1461,7 +1462,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1482,7 +1483,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1503,7 +1504,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1524,7 +1525,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1545,7 +1546,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1566,7 +1567,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Cell
@@ -1587,7 +1588,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1608,7 +1609,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1629,7 +1630,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1650,7 +1651,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1671,7 +1672,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: CellularComponent
@@ -1692,7 +1693,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1713,7 +1714,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1734,7 +1735,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1755,7 +1756,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1776,7 +1777,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1797,7 +1798,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1818,7 +1819,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1839,7 +1840,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: AnatomicalEntity
@@ -1860,7 +1861,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: ChemicalSubstance
@@ -1881,7 +1882,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: BiologicalProcess
@@ -1902,7 +1903,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease
@@ -1923,7 +1924,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: PhenotypicFeature
@@ -1944,7 +1945,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Gene
@@ -1965,7 +1966,7 @@ components:
       - id: UMLS
         semantic: PhenotypicFeature
       method: post
-      source: SEMMED
+      source: "infores:semmeddb"
       outputs:
       - id: UMLS
         semantic: Disease

--- a/tcga_mut_freq/smartapi.yaml
+++ b/tcga_mut_freq/smartapi.yaml
@@ -10,6 +10,7 @@ info:
   title: TCGA Mutation Frequency KP API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-tcga-mut-freq"
     component: KP
     team:
       - Multiomics Provider
@@ -392,7 +393,8 @@ components:
       predicate: condition_associated_with_gene
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/disease-gene'
-      source: Multiomics Provider
+      ## note that this is a data source
+      source: "infores:tgca"
       supportBatch: false
     gene-disease:
     - inputs:
@@ -410,7 +412,8 @@ components:
       predicate: gene_associated_with_condition 
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/gene-disease'
-      source: Multiomics Provider
+      ## note that this is a data source
+      source: "infores:tgca"
       supportBatch: false
   x-bte-response-mapping:
     disease-gene:

--- a/text_mining/cooccurrence.yaml
+++ b/text_mining/cooccurrence.yaml
@@ -10,6 +10,7 @@ info:
   title: Text Mining CO-OCCURRENCE API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:text-mining-provider-cooccurrence"
     component: KP
     team:
       - Text Mining Provider
@@ -679,7 +680,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-AnatomicalEntity-reverse:
     - inputs:
@@ -695,7 +696,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-BiologicalProcess:
     - inputs:
@@ -711,7 +712,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-BiologicalProcess-reverse:
     - inputs:
@@ -727,7 +728,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-Cell:
     - inputs:
@@ -743,7 +744,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-Cell-reverse:
     - inputs:
@@ -759,7 +760,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-CellularComponent:
     - inputs:
@@ -775,7 +776,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-CellularComponent-reverse:
     - inputs:
@@ -791,7 +792,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-ChemicalSubstance:
     - inputs:
@@ -807,7 +808,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-ChemicalSubstance-reverse:
     - inputs:
@@ -823,7 +824,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-Disease:
     - inputs:
@@ -839,7 +840,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-Disease-reverse:
     - inputs:
@@ -855,7 +856,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-Gene:
     - inputs:
@@ -871,7 +872,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-Gene-reverse:
     - inputs:
@@ -887,7 +888,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-MolecularActivity:
     - inputs:
@@ -903,7 +904,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-MolecularActivity-reverse:
     - inputs:
@@ -919,7 +920,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-OrganismTaxon:
     - inputs:
@@ -935,7 +936,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-OrganismTaxon-reverse:
     - inputs:
@@ -951,7 +952,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-PhenotypicFeature:
     - inputs:
@@ -967,7 +968,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-PhenotypicFeature-reverse:
     - inputs:
@@ -983,7 +984,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-Protein:
     - inputs:
@@ -999,7 +1000,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-Protein-reverse:
     - inputs:
@@ -1015,7 +1016,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-SequenceFeature:
     - inputs:
@@ -1031,7 +1032,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     AnatomicalEntity-SequenceFeature-reverse:
     - inputs:
@@ -1047,7 +1048,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-AnatomicalEntity:
     - inputs:
@@ -1063,7 +1064,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-AnatomicalEntity-reverse:
     - inputs:
@@ -1079,7 +1080,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-BiologicalProcess:
     - inputs:
@@ -1095,7 +1096,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-BiologicalProcess-reverse:
     - inputs:
@@ -1111,7 +1112,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-Cell:
     - inputs:
@@ -1127,7 +1128,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-Cell-reverse:
     - inputs:
@@ -1143,7 +1144,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-CellularComponent:
     - inputs:
@@ -1159,7 +1160,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-CellularComponent-reverse:
     - inputs:
@@ -1175,7 +1176,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-ChemicalSubstance:
     - inputs:
@@ -1191,7 +1192,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-ChemicalSubstance-reverse:
     - inputs:
@@ -1207,7 +1208,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-Disease:
     - inputs:
@@ -1223,7 +1224,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-Disease-reverse:
     - inputs:
@@ -1239,7 +1240,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-Gene:
     - inputs:
@@ -1255,7 +1256,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-Gene-reverse:
     - inputs:
@@ -1271,7 +1272,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-MolecularActivity:
     - inputs:
@@ -1287,7 +1288,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-MolecularActivity-reverse:
     - inputs:
@@ -1303,7 +1304,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-OrganismTaxon:
     - inputs:
@@ -1319,7 +1320,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-OrganismTaxon-reverse:
     - inputs:
@@ -1335,7 +1336,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-PhenotypicFeature:
     - inputs:
@@ -1351,7 +1352,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-PhenotypicFeature-reverse:
     - inputs:
@@ -1367,7 +1368,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-Protein:
     - inputs:
@@ -1383,7 +1384,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-Protein-reverse:
     - inputs:
@@ -1399,7 +1400,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-SequenceFeature:
     - inputs:
@@ -1415,7 +1416,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     BiologicalProcess-SequenceFeature-reverse:
     - inputs:
@@ -1431,7 +1432,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-AnatomicalEntity:
     - inputs:
@@ -1447,7 +1448,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-AnatomicalEntity-reverse:
     - inputs:
@@ -1463,7 +1464,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-BiologicalProcess:
     - inputs:
@@ -1479,7 +1480,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-BiologicalProcess-reverse:
     - inputs:
@@ -1495,7 +1496,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-Cell:
     - inputs:
@@ -1511,7 +1512,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-Cell-reverse:
     - inputs:
@@ -1527,7 +1528,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-CellularComponent:
     - inputs:
@@ -1543,7 +1544,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-CellularComponent-reverse:
     - inputs:
@@ -1559,7 +1560,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-ChemicalSubstance:
     - inputs:
@@ -1575,7 +1576,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-ChemicalSubstance-reverse:
     - inputs:
@@ -1591,7 +1592,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-Disease:
     - inputs:
@@ -1607,7 +1608,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-Disease-reverse:
     - inputs:
@@ -1623,7 +1624,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-Gene:
     - inputs:
@@ -1639,7 +1640,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-Gene-reverse:
     - inputs:
@@ -1655,7 +1656,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-MolecularActivity:
     - inputs:
@@ -1671,7 +1672,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-MolecularActivity-reverse:
     - inputs:
@@ -1687,7 +1688,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-OrganismTaxon:
     - inputs:
@@ -1703,7 +1704,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-OrganismTaxon-reverse:
     - inputs:
@@ -1719,7 +1720,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-PhenotypicFeature:
     - inputs:
@@ -1735,7 +1736,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-PhenotypicFeature-reverse:
     - inputs:
@@ -1751,7 +1752,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-Protein:
     - inputs:
@@ -1767,7 +1768,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-Protein-reverse:
     - inputs:
@@ -1783,7 +1784,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-SequenceFeature:
     - inputs:
@@ -1799,7 +1800,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Cell-SequenceFeature-reverse:
     - inputs:
@@ -1815,7 +1816,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-AnatomicalEntity:
     - inputs:
@@ -1831,7 +1832,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-AnatomicalEntity-reverse:
     - inputs:
@@ -1847,7 +1848,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-BiologicalProcess:
     - inputs:
@@ -1863,7 +1864,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-BiologicalProcess-reverse:
     - inputs:
@@ -1879,7 +1880,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-Cell:
     - inputs:
@@ -1895,7 +1896,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-Cell-reverse:
     - inputs:
@@ -1911,7 +1912,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-CellularComponent:
     - inputs:
@@ -1927,7 +1928,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-CellularComponent-reverse:
     - inputs:
@@ -1943,7 +1944,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-ChemicalSubstance:
     - inputs:
@@ -1959,7 +1960,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-ChemicalSubstance-reverse:
     - inputs:
@@ -1975,7 +1976,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-Disease:
     - inputs:
@@ -1991,7 +1992,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-Disease-reverse:
     - inputs:
@@ -2007,7 +2008,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-Gene:
     - inputs:
@@ -2023,7 +2024,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-Gene-reverse:
     - inputs:
@@ -2039,7 +2040,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-MolecularActivity:
     - inputs:
@@ -2055,7 +2056,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-MolecularActivity-reverse:
     - inputs:
@@ -2071,7 +2072,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-OrganismTaxon:
     - inputs:
@@ -2087,7 +2088,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-OrganismTaxon-reverse:
     - inputs:
@@ -2103,7 +2104,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-PhenotypicFeature:
     - inputs:
@@ -2119,7 +2120,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-PhenotypicFeature-reverse:
     - inputs:
@@ -2135,7 +2136,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-Protein:
     - inputs:
@@ -2151,7 +2152,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-Protein-reverse:
     - inputs:
@@ -2167,7 +2168,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-SequenceFeature:
     - inputs:
@@ -2183,7 +2184,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     CellularComponent-SequenceFeature-reverse:
     - inputs:
@@ -2199,7 +2200,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-AnatomicalEntity:
     - inputs:
@@ -2215,7 +2216,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-AnatomicalEntity-reverse:
     - inputs:
@@ -2231,7 +2232,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-BiologicalProcess:
     - inputs:
@@ -2247,7 +2248,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-BiologicalProcess-reverse:
     - inputs:
@@ -2263,7 +2264,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-Cell:
     - inputs:
@@ -2279,7 +2280,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-Cell-reverse:
     - inputs:
@@ -2295,7 +2296,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-CellularComponent:
     - inputs:
@@ -2311,7 +2312,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-CellularComponent-reverse:
     - inputs:
@@ -2327,7 +2328,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-ChemicalSubstance:
     - inputs:
@@ -2343,7 +2344,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-ChemicalSubstance-reverse:
     - inputs:
@@ -2359,7 +2360,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-Disease:
     - inputs:
@@ -2375,7 +2376,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-Disease-reverse:
     - inputs:
@@ -2391,7 +2392,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-Gene:
     - inputs:
@@ -2407,7 +2408,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-Gene-reverse:
     - inputs:
@@ -2423,7 +2424,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-MolecularActivity:
     - inputs:
@@ -2439,7 +2440,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-MolecularActivity-reverse:
     - inputs:
@@ -2455,7 +2456,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-OrganismTaxon:
     - inputs:
@@ -2471,7 +2472,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-OrganismTaxon-reverse:
     - inputs:
@@ -2487,7 +2488,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-PhenotypicFeature:
     - inputs:
@@ -2503,7 +2504,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-PhenotypicFeature-reverse:
     - inputs:
@@ -2519,7 +2520,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-Protein:
     - inputs:
@@ -2535,7 +2536,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-Protein-reverse:
     - inputs:
@@ -2551,7 +2552,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-SequenceFeature:
     - inputs:
@@ -2567,7 +2568,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     ChemicalSubstance-SequenceFeature-reverse:
     - inputs:
@@ -2583,7 +2584,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-AnatomicalEntity:
     - inputs:
@@ -2599,7 +2600,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-AnatomicalEntity-reverse:
     - inputs:
@@ -2615,7 +2616,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-BiologicalProcess:
     - inputs:
@@ -2631,7 +2632,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-BiologicalProcess-reverse:
     - inputs:
@@ -2647,7 +2648,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-Cell:
     - inputs:
@@ -2663,7 +2664,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-Cell-reverse:
     - inputs:
@@ -2679,7 +2680,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-CellularComponent:
     - inputs:
@@ -2695,7 +2696,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-CellularComponent-reverse:
     - inputs:
@@ -2711,7 +2712,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-ChemicalSubstance:
     - inputs:
@@ -2727,7 +2728,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-ChemicalSubstance-reverse:
     - inputs:
@@ -2743,7 +2744,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-Disease:
     - inputs:
@@ -2759,7 +2760,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-Disease-reverse:
     - inputs:
@@ -2775,7 +2776,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-Gene:
     - inputs:
@@ -2791,7 +2792,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-Gene-reverse:
     - inputs:
@@ -2807,7 +2808,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-MolecularActivity:
     - inputs:
@@ -2823,7 +2824,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-MolecularActivity-reverse:
     - inputs:
@@ -2839,7 +2840,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-OrganismTaxon:
     - inputs:
@@ -2855,7 +2856,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-OrganismTaxon-reverse:
     - inputs:
@@ -2871,7 +2872,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-PhenotypicFeature:
     - inputs:
@@ -2887,7 +2888,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-PhenotypicFeature-reverse:
     - inputs:
@@ -2903,7 +2904,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-Protein:
     - inputs:
@@ -2919,7 +2920,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-Protein-reverse:
     - inputs:
@@ -2935,7 +2936,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-SequenceFeature:
     - inputs:
@@ -2951,7 +2952,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Disease-SequenceFeature-reverse:
     - inputs:
@@ -2967,7 +2968,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-AnatomicalEntity:
     - inputs:
@@ -2983,7 +2984,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-AnatomicalEntity-reverse:
     - inputs:
@@ -2999,7 +3000,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-BiologicalProcess:
     - inputs:
@@ -3015,7 +3016,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-BiologicalProcess-reverse:
     - inputs:
@@ -3031,7 +3032,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-Cell:
     - inputs:
@@ -3047,7 +3048,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-Cell-reverse:
     - inputs:
@@ -3063,7 +3064,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-CellularComponent:
     - inputs:
@@ -3079,7 +3080,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-CellularComponent-reverse:
     - inputs:
@@ -3095,7 +3096,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-ChemicalSubstance:
     - inputs:
@@ -3111,7 +3112,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-ChemicalSubstance-reverse:
     - inputs:
@@ -3127,7 +3128,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-Disease:
     - inputs:
@@ -3143,7 +3144,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-Disease-reverse:
     - inputs:
@@ -3159,7 +3160,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-Gene:
     - inputs:
@@ -3175,7 +3176,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-Gene-reverse:
     - inputs:
@@ -3191,7 +3192,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-MolecularActivity:
     - inputs:
@@ -3207,7 +3208,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-MolecularActivity-reverse:
     - inputs:
@@ -3223,7 +3224,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-OrganismTaxon:
     - inputs:
@@ -3239,7 +3240,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-OrganismTaxon-reverse:
     - inputs:
@@ -3255,7 +3256,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-PhenotypicFeature:
     - inputs:
@@ -3271,7 +3272,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-PhenotypicFeature-reverse:
     - inputs:
@@ -3287,7 +3288,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-Protein:
     - inputs:
@@ -3303,7 +3304,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-Protein-reverse:
     - inputs:
@@ -3319,7 +3320,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-SequenceFeature:
     - inputs:
@@ -3335,7 +3336,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Gene-SequenceFeature-reverse:
     - inputs:
@@ -3351,7 +3352,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-AnatomicalEntity:
     - inputs:
@@ -3367,7 +3368,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-AnatomicalEntity-reverse:
     - inputs:
@@ -3383,7 +3384,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-BiologicalProcess:
     - inputs:
@@ -3399,7 +3400,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-BiologicalProcess-reverse:
     - inputs:
@@ -3415,7 +3416,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-Cell:
     - inputs:
@@ -3431,7 +3432,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-Cell-reverse:
     - inputs:
@@ -3447,7 +3448,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-CellularComponent:
     - inputs:
@@ -3463,7 +3464,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-CellularComponent-reverse:
     - inputs:
@@ -3479,7 +3480,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-ChemicalSubstance:
     - inputs:
@@ -3495,7 +3496,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-ChemicalSubstance-reverse:
     - inputs:
@@ -3511,7 +3512,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-Disease:
     - inputs:
@@ -3527,7 +3528,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-Disease-reverse:
     - inputs:
@@ -3543,7 +3544,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-Gene:
     - inputs:
@@ -3559,7 +3560,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-Gene-reverse:
     - inputs:
@@ -3575,7 +3576,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-MolecularActivity:
     - inputs:
@@ -3591,7 +3592,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-MolecularActivity-reverse:
     - inputs:
@@ -3607,7 +3608,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-OrganismTaxon:
     - inputs:
@@ -3623,7 +3624,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-OrganismTaxon-reverse:
     - inputs:
@@ -3639,7 +3640,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-PhenotypicFeature:
     - inputs:
@@ -3655,7 +3656,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-PhenotypicFeature-reverse:
     - inputs:
@@ -3671,7 +3672,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-Protein:
     - inputs:
@@ -3687,7 +3688,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-Protein-reverse:
     - inputs:
@@ -3703,7 +3704,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-SequenceFeature:
     - inputs:
@@ -3719,7 +3720,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     MolecularActivity-SequenceFeature-reverse:
     - inputs:
@@ -3735,7 +3736,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-AnatomicalEntity:
     - inputs:
@@ -3751,7 +3752,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-AnatomicalEntity-reverse:
     - inputs:
@@ -3767,7 +3768,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-BiologicalProcess:
     - inputs:
@@ -3783,7 +3784,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-BiologicalProcess-reverse:
     - inputs:
@@ -3799,7 +3800,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-Cell:
     - inputs:
@@ -3815,7 +3816,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-Cell-reverse:
     - inputs:
@@ -3831,7 +3832,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-CellularComponent:
     - inputs:
@@ -3847,7 +3848,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-CellularComponent-reverse:
     - inputs:
@@ -3863,7 +3864,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-ChemicalSubstance:
     - inputs:
@@ -3879,7 +3880,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-ChemicalSubstance-reverse:
     - inputs:
@@ -3895,7 +3896,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-Disease:
     - inputs:
@@ -3911,7 +3912,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-Disease-reverse:
     - inputs:
@@ -3927,7 +3928,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-Gene:
     - inputs:
@@ -3943,7 +3944,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-Gene-reverse:
     - inputs:
@@ -3959,7 +3960,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-MolecularActivity:
     - inputs:
@@ -3975,7 +3976,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-MolecularActivity-reverse:
     - inputs:
@@ -3991,7 +3992,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-OrganismTaxon:
     - inputs:
@@ -4007,7 +4008,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-OrganismTaxon-reverse:
     - inputs:
@@ -4023,7 +4024,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-PhenotypicFeature:
     - inputs:
@@ -4039,7 +4040,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-PhenotypicFeature-reverse:
     - inputs:
@@ -4055,7 +4056,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-Protein:
     - inputs:
@@ -4071,7 +4072,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-Protein-reverse:
     - inputs:
@@ -4087,7 +4088,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-SequenceFeature:
     - inputs:
@@ -4103,7 +4104,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     OrganismTaxon-SequenceFeature-reverse:
     - inputs:
@@ -4119,7 +4120,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-AnatomicalEntity:
     - inputs:
@@ -4135,7 +4136,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-AnatomicalEntity-reverse:
     - inputs:
@@ -4151,7 +4152,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-BiologicalProcess:
     - inputs:
@@ -4167,7 +4168,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-BiologicalProcess-reverse:
     - inputs:
@@ -4183,7 +4184,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-Cell:
     - inputs:
@@ -4199,7 +4200,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-Cell-reverse:
     - inputs:
@@ -4215,7 +4216,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-CellularComponent:
     - inputs:
@@ -4231,7 +4232,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-CellularComponent-reverse:
     - inputs:
@@ -4247,7 +4248,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-ChemicalSubstance:
     - inputs:
@@ -4263,7 +4264,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-ChemicalSubstance-reverse:
     - inputs:
@@ -4279,7 +4280,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-Disease:
     - inputs:
@@ -4295,7 +4296,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-Disease-reverse:
     - inputs:
@@ -4311,7 +4312,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-Gene:
     - inputs:
@@ -4327,7 +4328,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-Gene-reverse:
     - inputs:
@@ -4343,7 +4344,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-MolecularActivity:
     - inputs:
@@ -4359,7 +4360,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-MolecularActivity-reverse:
     - inputs:
@@ -4375,7 +4376,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-OrganismTaxon:
     - inputs:
@@ -4391,7 +4392,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-OrganismTaxon-reverse:
     - inputs:
@@ -4407,7 +4408,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-PhenotypicFeature:
     - inputs:
@@ -4423,7 +4424,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-PhenotypicFeature-reverse:
     - inputs:
@@ -4439,7 +4440,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-Protein:
     - inputs:
@@ -4455,7 +4456,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-Protein-reverse:
     - inputs:
@@ -4471,7 +4472,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-SequenceFeature:
     - inputs:
@@ -4487,7 +4488,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     PhenotypicFeature-SequenceFeature-reverse:
     - inputs:
@@ -4503,7 +4504,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-AnatomicalEntity:
     - inputs:
@@ -4519,7 +4520,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-AnatomicalEntity-reverse:
     - inputs:
@@ -4535,7 +4536,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-BiologicalProcess:
     - inputs:
@@ -4551,7 +4552,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-BiologicalProcess-reverse:
     - inputs:
@@ -4567,7 +4568,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-Cell:
     - inputs:
@@ -4583,7 +4584,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-Cell-reverse:
     - inputs:
@@ -4599,7 +4600,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-CellularComponent:
     - inputs:
@@ -4615,7 +4616,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-CellularComponent-reverse:
     - inputs:
@@ -4631,7 +4632,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-ChemicalSubstance:
     - inputs:
@@ -4647,7 +4648,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-ChemicalSubstance-reverse:
     - inputs:
@@ -4663,7 +4664,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-Disease:
     - inputs:
@@ -4679,7 +4680,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-Disease-reverse:
     - inputs:
@@ -4695,7 +4696,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-Gene:
     - inputs:
@@ -4711,7 +4712,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-Gene-reverse:
     - inputs:
@@ -4727,7 +4728,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-MolecularActivity:
     - inputs:
@@ -4743,7 +4744,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-MolecularActivity-reverse:
     - inputs:
@@ -4759,7 +4760,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-OrganismTaxon:
     - inputs:
@@ -4775,7 +4776,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-OrganismTaxon-reverse:
     - inputs:
@@ -4791,7 +4792,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-PhenotypicFeature:
     - inputs:
@@ -4807,7 +4808,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-PhenotypicFeature-reverse:
     - inputs:
@@ -4823,7 +4824,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-Protein:
     - inputs:
@@ -4839,7 +4840,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-Protein-reverse:
     - inputs:
@@ -4855,7 +4856,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-SequenceFeature:
     - inputs:
@@ -4871,7 +4872,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     Protein-SequenceFeature-reverse:
     - inputs:
@@ -4887,7 +4888,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-AnatomicalEntity:
     - inputs:
@@ -4903,7 +4904,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-AnatomicalEntity-reverse:
     - inputs:
@@ -4919,7 +4920,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/AnatomicalEntity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-BiologicalProcess:
     - inputs:
@@ -4935,7 +4936,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-BiologicalProcess-reverse:
     - inputs:
@@ -4951,7 +4952,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/BiologicalProcess-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-Cell:
     - inputs:
@@ -4967,7 +4968,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-Cell-reverse:
     - inputs:
@@ -4983,7 +4984,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Cell-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-CellularComponent:
     - inputs:
@@ -4999,7 +5000,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-CellularComponent-reverse:
     - inputs:
@@ -5015,7 +5016,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/CellularComponent-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-ChemicalSubstance:
     - inputs:
@@ -5031,7 +5032,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-ChemicalSubstance-reverse:
     - inputs:
@@ -5047,7 +5048,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-Disease:
     - inputs:
@@ -5063,7 +5064,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-Disease-reverse:
     - inputs:
@@ -5079,7 +5080,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-Gene:
     - inputs:
@@ -5095,7 +5096,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-Gene-reverse:
     - inputs:
@@ -5111,7 +5112,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Gene-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-MolecularActivity:
     - inputs:
@@ -5127,7 +5128,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-MolecularActivity-reverse:
     - inputs:
@@ -5143,7 +5144,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/MolecularActivity-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-OrganismTaxon:
     - inputs:
@@ -5159,7 +5160,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-OrganismTaxon-reverse:
     - inputs:
@@ -5175,7 +5176,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/OrganismTaxon-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-PhenotypicFeature:
     - inputs:
@@ -5191,7 +5192,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-PhenotypicFeature-reverse:
     - inputs:
@@ -5207,7 +5208,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-Protein:
     - inputs:
@@ -5223,7 +5224,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-Protein-reverse:
     - inputs:
@@ -5239,7 +5240,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Protein-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-SequenceFeature:
     - inputs:
@@ -5255,7 +5256,7 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
     SequenceFeature-SequenceFeature-reverse:
     - inputs:
@@ -5271,9 +5272,8 @@ components:
       predicate: related_to
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/SequenceFeature-reverse'
-      source: Text Mining KP
+      # source: Text Mining KP
       supportBatch: false
-    
   x-bte-response-mapping:
     AnatomicalEntity:
       UBERON: hits.object.UBERON

--- a/text_mining/smartapi.yaml
+++ b/text_mining/smartapi.yaml
@@ -10,6 +10,7 @@ info:
   title: Text Mining Targeted Association API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:text-mining-provider-targeted"
     component: KP
     team:
       - Text Mining Provider
@@ -394,7 +395,8 @@ components:
       predicate: entity_positively_regulates_entity
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/chemical-protein'
-      source: Text Mining KP
+      ## note: source should be the source of data used
+      # source: Text Mining KP
       supportBatch: false
     chemical-protein-negative:
     - inputs:
@@ -410,7 +412,8 @@ components:
       predicate: entity_negatively_regulates_entity
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/chemical-protein'
-      source: Text Mining KP
+      ## note: source should be the source of data used
+      # source: Text Mining KP
       supportBatch: false
     protein-chemical-positive:
     - outputs:
@@ -426,7 +429,8 @@ components:
       predicate: entity_positively_regulated_by_entity
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/protein-chemical'
-      source: Text Mining KP
+      ## note: source should be the source of data used
+      # source: Text Mining KP
       supportBatch: false
     protein-chemical-negative:
     - outputs:
@@ -442,7 +446,8 @@ components:
       predicate: entity_negatively_regulated_by_entity
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/protein-chemical'
-      source: Text Mining KP
+      ## note: source should be the source of data used
+      # source: Text Mining KP
       supportBatch: false
   x-bte-response-mapping:
     chemical-protein:

--- a/uberon/smartapi.yaml
+++ b/uberon/smartapi.yaml
@@ -10,6 +10,7 @@ info:
   title: UBERON Ontology API
   version: '1.0'
   x-translator:
+    infores-curie: "infores:biothings-uberon-ontology"
     component: KP
     team:
       - Service Provider
@@ -398,7 +399,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/has_subclass'
-      source: UBERON Ontology
+      source: "infores:uberon"
       supportBatch: true
     subclass_of:
     - inputSeparator: ','
@@ -418,7 +419,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/subclass_of'
-      source: UBERON Ontology
+      source: "infores:uberon"
       supportBatch: true
     part_of:
     - inputSeparator: ','
@@ -438,7 +439,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/part_of'
-      source: UBERON Ontology
+      source: "infores:uberon"
       supportBatch: true
     has_part:
     - inputSeparator: ','
@@ -458,7 +459,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/has_part'
-      source: UBERON Ontology
+      source: "infores:uberon"
       supportBatch: true
     produces:
     - inputSeparator: ','
@@ -478,7 +479,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/produces'
-      source: UBERON Ontology
+      source: "infores:uberon"
       supportBatch: true
     produced_by:
     - inputSeparator: ','
@@ -498,7 +499,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/produced_by'
-      source: UBERON Ontology
+      source: "infores:uberon"
       supportBatch: true
     located_in:
     - inputSeparator: ','
@@ -518,7 +519,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/located_in'
-      source: UBERON Ontology
+      source: "infores:uberon"
       supportBatch: true
     location_of:
     - inputSeparator: ','
@@ -538,7 +539,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/location_of'
-      source: UBERON Ontology
+      source: "infores:uberon"
       supportBatch: true
     develops_from:
     - inputSeparator: ','
@@ -558,7 +559,7 @@ components:
         header: application/x-www-form-urlencoded
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/develops_from'
-      source: UBERON Ontology
+      source: "infores:uberon"
       supportBatch: true
   x-bte-response-mapping:
     has_subclass:


### PR DESCRIPTION
fix: add x-translator.infores-curie, replace source strings with infores curies

also note: 3 apis don't have the hard-coded source field now:
- text mining co-occurrence api
- text mining targeted association api
- drug response kp api

also note: one api fits situation C of https://github.com/biothings/BioThings_Explorer_TRAPI/issues/208\#issuecomment-866620512: tcga mutational freq api