### PR TITLE
HPO for MyVariant Clinvar Variant-Disease

### DIFF
--- a/myvariant.info/openapi_full.yml
+++ b/myvariant.info/openapi_full.yml
@@ -38,14 +38,11 @@ paths:
         for an example and [here](https://docs.myvariant.info/en/latest/doc/data.html#variant-object)
         for more details. If the input variant ID is not valid, 404 (NOT FOUND) will be returned.
         
-
         Optionally, you can pass a "fields" parameter to return only the annotation you want 
         (by filtering returned object fields). "fields" accepts any attributes (a.k.a fields) available 
         from the chemical object. Multiple attributes should be separated by commas. If an attribute is not 
         available for a specific variant object, it will be ignored. Note that the attribute names are 
         case-sensitive.
-
-
         Just like the variant query service, you can also pass a "callback" parameter to make a JSONP call.
       parameters:
       ## these are provided in the docs https://docs.myvariant.info/en/latest/doc/variant_annotation_service.html
@@ -99,8 +96,6 @@ paths:
           Required. Accepts multiple HGVS variant ids separated by comma, 
           e.g., "ids=chr6:g.152708291G>A,chr7:g.55241707G>T,chr16:g.28883241A>G". 
           Note that currently we only take the input ids up to 1000 maximum, the rest will be omitted.
-
-
           The request body can also be used to provide these ids.
         in: query
         ## setting to false since putting this info in the request body seems to work as well
@@ -231,8 +226,6 @@ paths:
         Although making simple GET requests above to our variant query service is sufficient for most use cases, 
         there are times you might find it more efficient to make batch queries (e.g., retrieving variant annotation 
         for multiple variants). Fortunately, you can also make batch queries via POST requests when you need to.
-
-
         The "query" field in the returned object indicates the matching query term. If a query term has no match, 
         it will return with a "notfound" field with the value "true".
       parameters:
@@ -241,8 +234,6 @@ paths:
         description: >-
           Accepts multiple values separated by commas. Note that currently we only take the input values up to 1000 
           maximum, the rest will be omitted.
-
-
           The request body can also be used to provide these ids.
         in: query
         ## setting to false since putting this info in the request body seems to work as well
@@ -256,8 +247,6 @@ paths:
           Optional, specify one or more fields (separated by commas) to search, e.g., "scopes=dbsnp.rsid". 
           The available "fields" can be passed to "scopes" parameter are listed 
           [here](https://docs.myvariant.info/en/latest/doc/data.html#available-fields). Default: _id
-
-
           The request body can also be used to provide this information.
         in: query
         ## setting to false since putting this info in the request body seems to work as well
@@ -427,7 +416,6 @@ components:
         If "fields=all", all available fields will be returned. Look 
         [here](https://docs.mychem.info/en/latest/doc/data.html#available-fields) for a list of available fields. 
         
-
         Note that it supports dot notation as well, e.g., you can pass "chebi.name". 
         Default: "fields=all". 
         The parameter "filter" is an alias for this parameter.
@@ -676,8 +664,6 @@ components:
     clinvar-variantDisease:
       OMIM: clinvar.rcv.conditions.identifiers.omim  ## no prefix
       HP: clinvar.rcv.conditions.identifiers.human_phenotype_ontology
-      MESH: clinvar.rcv.conditions.identifiers.mesh
-      MONDO: clinvar.rcv.conditions.identifiers.mondo
       ## edge attributes
       clinvar_clinical_significance: clinvar.rcv.clinical_significance  ## similar to relation
       clinvar_variant_in_gene: clinvar.gene.symbol    ## context: gene
@@ -992,18 +978,12 @@ components:
       outputs:
       - id: OMIM
         semantic: Disease
-      - id: MESH
-        semantic: Disease
-      - id: MONDO
-        semantic: Disease
       - id: HP
         semantic: Disease
       parameters:
       ## using gene symbol rather than gene.id so it's human-readable
         fields: >-
           clinvar.rcv.conditions.identifiers.omim,
-          clinvar.rcv.conditions.identifiers.mesh,
-          clinvar.rcv.conditions.identifiers.mondo,
           clinvar.rcv.conditions.identifiers.human_phenotype_ontology,
           clinvar.rcv.clinical_significance,
           clinvar.gene.symbol,

--- a/myvariant.info/openapi_full.yml
+++ b/myvariant.info/openapi_full.yml
@@ -675,6 +675,9 @@ components:
       NCBIGene: clinvar.gene.id  ## no prefix
     clinvar-variantDisease:
       OMIM: clinvar.rcv.conditions.identifiers.omim  ## no prefix
+      HP: clinvar.rcv.conditions.identifiers.human_phenotype_ontology
+      MESH: clinvar.rcv.conditions.identifiers.mesh
+      MONDO: clinvar.rcv.conditions.identifiers.mondo
       ## edge attributes
       clinvar_clinical_significance: clinvar.rcv.clinical_significance  ## similar to relation
       clinvar_variant_in_gene: clinvar.gene.symbol    ## context: gene
@@ -989,10 +992,19 @@ components:
       outputs:
       - id: OMIM
         semantic: Disease
+      - id: MESH
+        semantic: Disease
+      - id: MONDO
+        semantic: Disease
+      - id: HP
+        semantic: Disease
       parameters:
       ## using gene symbol rather than gene.id so it's human-readable
         fields: >-
-          clinvar.rcv.conditions.identifiers.omim,
+          clinvar.rcv.conditions.identifiers.mondo,
+          clinvar.rcv.conditions.identifiers.mesh,
+          clinvar.rcv.conditions.identifiers.mondo,
+          clinvar.rcv.conditions.identifiers.human_phenotype_ontology,
           clinvar.rcv.clinical_significance,
           clinvar.gene.symbol,
           clinvar.rcv.last_evaluated,

--- a/myvariant.info/openapi_full.yml
+++ b/myvariant.info/openapi_full.yml
@@ -1001,7 +1001,7 @@ components:
       parameters:
       ## using gene symbol rather than gene.id so it's human-readable
         fields: >-
-          clinvar.rcv.conditions.identifiers.mondo,
+          clinvar.rcv.conditions.identifiers.omim,
           clinvar.rcv.conditions.identifiers.mesh,
           clinvar.rcv.conditions.identifiers.mondo,
           clinvar.rcv.conditions.identifiers.human_phenotype_ontology,


### PR DESCRIPTION
Currently some clinvar variant-disease relations in myvariant do not have a omim id and therfore cannot be used by BTE with the current smartapi yaml. Here I am adding support for HPO ids.