### PR TITLE
Change semmeddb urls

### DIFF
--- a/semmeddb/smartapi.yaml
+++ b/semmeddb/smartapi.yaml
@@ -34,8 +34,7 @@ tags:
 - name: query
 - name: translator
 - name: biothings
-## might not have ngd endpoints
-# - name: ngd
+- name: ngd
 paths:
   "/association/{id}":
     get:
@@ -163,61 +162,60 @@ paths:
           description: A 200 status code indicates a successful query, and is accompanied by the query response payload.
       tags:
       - metadata
-## might not have ngd endpoints
-  # "/query/ngd":
-  #   get:
-  #     parameters:
-  #     - name: umls
-  #       description: Query string.
-  #       in: query
-  #       required: true
-  #       example: 
-  #       - "C0003762,C0262587"
-  #       schema:
-  #         type: array
-  #         items:
-  #           type: string
-  #     ## these are noted in the /spec endpoint; commenting out for now
-  #     # - "$ref": "#/components/parameters/format"
-  #     responses:
-  #       '200':
-  #         description: Success
-  #     tags:
-  #     - ngd
-  #   post:
-  #     parameters:
-  #     - name: umls
-  #       description: Query string.
-  #       in: query
-  #       required: false
-  #       schema:
-  #         type: array
-  #         items:
-  #           type: string
-  #     ## these are noted in the /spec endpoint; commenting out for now
-  #     # - "$ref": "#/components/parameters/format"
-  #     requestBody:
-  #       content:
-  #         application/json:
-  #           example:
-  #             umls:
-  #             - 
-  #               - C0003762
-  #               - C0262587
-  #           schema:
-  #             type: object
-  #             properties:
-  #               umls:
-  #                 type: array
-  #                 items:
-  #                   type: array
-  #                   items:
-  #                     type: string
-  #     responses:
-  #       '200':
-  #         description: Success
-  #     tags:
-  #     - ngd
+  "/query/ngd":
+    get:
+      parameters:
+      - name: umls
+        description: Query string.
+        in: query
+        required: true
+        example: 
+        - "C0003762,C0262587"
+        schema:
+          type: array
+          items:
+            type: string
+      ## these are noted in the /spec endpoint; commenting out for now
+      # - "$ref": "#/components/parameters/format"
+      responses:
+        '200':
+          description: Success
+      tags:
+      - ngd
+    post:
+      parameters:
+      - name: umls
+        description: Query string.
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+      ## these are noted in the /spec endpoint; commenting out for now
+      # - "$ref": "#/components/parameters/format"
+      requestBody:
+        content:
+          application/json:
+            example:
+              umls:
+              - 
+                - C0003762
+                - C0262587
+            schema:
+              type: object
+              properties:
+                umls:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: string
+      responses:
+        '200':
+          description: Success
+      tags:
+      - ngd
   "/query":
     get:
       description: >-

--- a/semmeddb/smartapi.yaml
+++ b/semmeddb/smartapi.yaml
@@ -22,7 +22,7 @@ info:
     biolink-version: "3.1.1"
 servers:
 - description: Production server
-  url: https://biothings.ncats.io/semmeddb2
+  url: https://biothings.ncats.io/semmeddb
   x-maturity: production
 tags:
 ## has many biolink-model semantic types, more than the tags here

--- a/semmeddb/version_without_operations.yaml
+++ b/semmeddb/version_without_operations.yaml
@@ -34,8 +34,7 @@ tags:
 - name: query
 - name: translator
 - name: biothings
-## might not have ngd endpoints
-# - name: ngd
+- name: ngd
 paths:
   "/association/{id}":
     get:
@@ -163,61 +162,60 @@ paths:
           description: A 200 status code indicates a successful query, and is accompanied by the query response payload.
       tags:
       - metadata
-## might not have ngd endpoints
-  # "/query/ngd":
-  #   get:
-  #     parameters:
-  #     - name: umls
-  #       description: Query string.
-  #       in: query
-  #       required: true
-  #       example: 
-  #       - "C0003762,C0262587"
-  #       schema:
-  #         type: array
-  #         items:
-  #           type: string
-  #     ## these are noted in the /spec endpoint; commenting out for now
-  #     # - "$ref": "#/components/parameters/format"
-  #     responses:
-  #       '200':
-  #         description: Success
-  #     tags:
-  #     - ngd
-  #   post:
-  #     parameters:
-  #     - name: umls
-  #       description: Query string.
-  #       in: query
-  #       required: false
-  #       schema:
-  #         type: array
-  #         items:
-  #           type: string
-  #     ## these are noted in the /spec endpoint; commenting out for now
-  #     # - "$ref": "#/components/parameters/format"
-  #     requestBody:
-  #       content:
-  #         application/json:
-  #           example:
-  #             umls:
-  #             - 
-  #               - C0003762
-  #               - C0262587
-  #           schema:
-  #             type: object
-  #             properties:
-  #               umls:
-  #                 type: array
-  #                 items:
-  #                   type: array
-  #                   items:
-  #                     type: string
-  #     responses:
-  #       '200':
-  #         description: Success
-  #     tags:
-  #     - ngd
+  "/query/ngd":
+    get:
+      parameters:
+      - name: umls
+        description: Query string.
+        in: query
+        required: true
+        example: 
+        - "C0003762,C0262587"
+        schema:
+          type: array
+          items:
+            type: string
+      ## these are noted in the /spec endpoint; commenting out for now
+      # - "$ref": "#/components/parameters/format"
+      responses:
+        '200':
+          description: Success
+      tags:
+      - ngd
+    post:
+      parameters:
+      - name: umls
+        description: Query string.
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+      ## these are noted in the /spec endpoint; commenting out for now
+      # - "$ref": "#/components/parameters/format"
+      requestBody:
+        content:
+          application/json:
+            example:
+              umls:
+              - 
+                - C0003762
+                - C0262587
+            schema:
+              type: object
+              properties:
+                umls:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: string
+      responses:
+        '200':
+          description: Success
+      tags:
+      - ngd
   "/query":
     get:
       description: >-

--- a/semmeddb/version_without_operations.yaml
+++ b/semmeddb/version_without_operations.yaml
@@ -22,7 +22,7 @@ info:
     biolink-version: "3.1.1"
 servers:
 - description: Production server
-  url: https://biothings.ncats.io/semmeddb2
+  url: https://biothings.ncats.io/semmeddb
   x-maturity: production
 tags:
 ## has many biolink-model semantic types, more than the tags here


### PR DESCRIPTION
WAIT: once "semmeddb" urls take you to the new stuff, then merge this and refresh registration. BTE will then start using this rather than the "semmeddb2" urls (which will also work / just redirect to "semmeddb"...