### PR TITLE
TRAPI 1.4 sources support for Text Mining Targeted

### DIFF
--- a/mychem.info/openapi_full.yml
+++ b/mychem.info/openapi_full.yml
@@ -842,7 +842,7 @@ components:
         semantic: MolecularActivity
       requestBody:
         body:
-          q: "{{ queryInputs }}"  ## HAS PREFIX (RHEA)
+          q: "{{ queryInputs | replPrefix('RHEA') }}"  ## HAS PREFIX (RHEA)
           scopes: chebi.xrefs.rhea
       outputs:
       - id: CHEBI

--- a/rhea/smartapi.yaml
+++ b/rhea/smartapi.yaml
@@ -592,7 +592,7 @@ components:
         body:
           ## API data has prefix (RHEA)
           ## joinSafe is only needed if the delimiter isn't a comma
-          q: "{{ queryInputs }}"
+          q: "{{ queryInputs | replPrefix('RHEA') }}"
           scopes: "_id,children_rheas"
       outputs:
       - id: CHEBI
@@ -625,7 +625,7 @@ components:
         body:
           ## API data has prefix (RHEA)
           ## joinSafe is only needed if the delimiter isn't a comma
-          q: "{{ queryInputs }}"
+          q: "{{ queryInputs | replPrefix('RHEA') }}"
           scopes: "_id,children_rheas"
       outputs:
       - id: CHEBI
@@ -658,7 +658,7 @@ components:
         body:
           ## API data has prefix (RHEA)
           ## joinSafe is only needed if the delimiter isn't a comma
-          q: "{{ queryInputs }}"
+          q: "{{ queryInputs | replPrefix('RHEA') }}"
           scopes: "_id,children_rheas"
       outputs:
       - id: CHEBI
@@ -691,7 +691,7 @@ components:
         body:
           ## API data has prefix (RHEA)
           ## joinSafe is only needed if the delimiter isn't a comma
-          q: "{{ queryInputs }}"
+          q: "{{ queryInputs | replPrefix('RHEA') }}"
           scopes: "_id,children_rheas"
       outputs:
       - id: CHEBI


### PR DESCRIPTION
WAIT: only merge once BTE is migrating to have all instances TRAPI 1.4. In this process, the overrides will be removed - so BTE will use the registered yamls for these KPs. So merging this PR will get these registered yamls updated. Then we want to refresh the registration. 


