### PR TITLE
TRAPI 1.4 sources support for BigGIM-Drug-Response

### DIFF
--- a/drug_response_kp/smartapi.yaml
+++ b/drug_response_kp/smartapi.yaml
@@ -591,32 +591,32 @@ components:
   ## in the API's records:
   ## - subjects and objects can be Gene (NCBIGene), SmallMolecule (PUBCHEM.COMPOUND), Disease (MONDO)
   ## - predicates can be associated_with_resistance_to, associated_with_sensitivity_to
-  ##   gene_associated_with_condition, has_biomarker, has_target,
+  ##   gene_associated_with_condition, has_biomarker, physically_interacts_with,
   ##   physically_interacts_with, genetically_interacts_with,
   ##   negatively_correlated_with, positively_correlated_with
   ## - BTE automatically puts prefix on MONDO IDs, but prefix has to be added to other ID inputs 
   ## - currently, BTE will also accept response with Translator-prefix (api-response-transform module).
   ## - joinSafe is only needed if the delimiter isn't a comma
     gene-sensitivity-chem:
-    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=association.edge_label:"biolink:associated_with_sensitivity_to"
+    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=predicate:"biolink:associated_with_sensitivity_to"
     ##  95994 records  
       - supportBatch: true
         useTemplating: true ## flag to say templating is being used below
         inputs:
-          - id: NCBIGene
-            semantic: Gene
+          - id: NCBIGene #biolink prefix for id
+            semantic: Gene #category of id
         requestBodyType: object
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:associated_with_sensitivity_to"]') }} ],
-              "scopes": ["subject.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:associated_with_sensitivity_to"]') }} ], 
+              "scopes": ["subject.NCBIGene", "predicate"] 
             }
         parameters:
-          fields: object.PUBCHEM_COMPOUND,association.edge_attributes,sources
+          fields: object.pubchem_compound,attributes,sources #field to return
           size: 1000
         outputs:
-          - id: "PUBCHEM.COMPOUND"
+          - id: "PUBCHEM.COMPOUND" #
             semantic: SmallMolecule
         predicate: associated_with_sensitivity_to
         response_mapping:
@@ -634,11 +634,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('PUBCHEM.COMPOUND') | wrap( '["' , '","biolink:associated_with_sensitivity_to"]') }} ],
-              "scopes": ["object.PUBCHEM_COMPOUND", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('PUBCHEM.COMPOUND') | wrap( '["' , '","biolink:associated_with_sensitivity_to"]') }} ],
+              "scopes": ["object.pubchem_compound", "predicate"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,sources
+          fields: subject.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -650,7 +650,7 @@ components:
         #   - qInput: "PUBCHEM.COMPOUND:24856436"       ## JNK-9L (Adavosertib)
         #     oneOutput: "NCBIGene:59352"               ## LGR6
     gene-resistance-chem:
-    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=association.edge_label:"biolink:associated_with_resistance_to"
+    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=predicate:"biolink:associated_with_resistance_to"
     ##  107719 records
       - supportBatch: true
         useTemplating: true ## flag to say templating is being used below
@@ -661,11 +661,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:associated_with_resistance_to"]') }} ],
-              "scopes": ["subject.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:associated_with_resistance_to"]') }} ],
+              "scopes": ["subject.NCBIGene", "predicate"]
             }
         parameters:
-          fields: object.PUBCHEM_COMPOUND,association.edge_attributes,sources
+          fields: object.pubchem_compound,attributes,sources
           size: 1000
         outputs:
           - id: "PUBCHEM.COMPOUND"
@@ -686,11 +686,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('PUBCHEM.COMPOUND') | wrap( '["' , '","biolink:associated_with_resistance_to"]') }} ],
-              "scopes": ["object.PUBCHEM_COMPOUND", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('PUBCHEM.COMPOUND') | wrap( '["' , '","biolink:associated_with_resistance_to"]') }} ],
+              "scopes": ["object.pubchem_compound", "predicate"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,sources
+          fields: subject.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -702,7 +702,7 @@ components:
         #   - qInput: "PUBCHEM.COMPOUND:46844147"       ## AZD8055 (Erk5-IN-1)
         #     oneOutput: "NCBIGene:26119"               ## LDLRAP1
     gene-associated-disease:
-    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=association.edge_label:"biolink:gene_associated_with_condition"
+    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=predicate:"biolink:gene_associated_with_condition"
     ##  922 records  
       - supportBatch: true
         useTemplating: true ## flag to say templating is being used below
@@ -713,11 +713,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:gene_associated_with_condition"]') }} ],
-              "scopes": ["subject.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:gene_associated_with_condition"]') }} ],
+              "scopes": ["subject.NCBIGene", "predicate"]
             }
         parameters:
-          fields: object.MONDO,association.edge_attributes,sources
+          fields: object.MONDO,attributes,sources
           size: 1000
         outputs:
           - id: MONDO
@@ -735,14 +735,14 @@ components:
           - id: MONDO
             semantic: Disease
         requestBodyType: object
-        requestBody:  ## don't need to addPrefix because BTE will automatically add prefix to MONDO IDs
+        requestBody:  
           body: >-
             {
-              "q": [ {{ queryInputs | wrap( '["' , '","biolink:gene_associated_with_condition"]') }} ],
-              "scopes": ["object.MONDO", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('MONDO') | wrap( '["' , '","biolink:gene_associated_with_condition"]') }} ],
+              "scopes": ["object.MONDO", "predicate"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,sources
+          fields: subject.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -754,7 +754,7 @@ components:
         #   - qInput: "MONDO:0004056"         ## TCGA-BLCA (bladder papillary urothelial carcinoma)
         #     oneOutput: "NCBIGene:7157"      ## TP53
     disease-biomarker-gene:
-    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=association.edge_label:"biolink:has_biomarker"
+    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=predicate:"biolink:has_biomarker"
     ##  13811 records  
       - supportBatch: true
         useTemplating: true ## flag to say templating is being used below
@@ -762,14 +762,14 @@ components:
           - id: MONDO
             semantic: Disease
         requestBodyType: object
-        requestBody:  ## don't need to addPrefix because BTE will automatically add prefix to MONDO IDs
+        requestBody:  
           body: >-
             {
-              "q": [ {{ queryInputs | wrap( '["' , '","biolink:has_biomarker"]') }} ],
-              "scopes": ["subject.MONDO", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('MONDO') | wrap( '["' , '","biolink:has_biomarker"]') }} ],
+              "scopes": ["subject.MONDO", "predicate"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,sources
+          fields: object.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -790,11 +790,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:has_biomarker"]') }} ],
-              "scopes": ["object.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:has_biomarker"]') }} ],
+              "scopes": ["object.NCBIGene", "predicate"]
             }
         parameters:
-          fields: subject.MONDO,association.edge_attributes,sources
+          fields: subject.MONDO,attributes,sources
           size: 1000
         outputs:
           - id: MONDO
@@ -805,9 +805,8 @@ components:
         # testExamples:
         #   - qInput: "NCBIGene:1145"         ## CHRNE
         #     oneOutput: "MONDO:0018874"      ## LAML (acute myeloid leukemia)
-## error around indexing subject.PUBCHEM_COMPOUND field. using subject.id until it's fixed
     chem-targets-gene:
-    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=association.edge_label:"biolink:has_target"
+    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=predicate:"biolink:physically_interacts_with"
     ##  14806 records
       - supportBatch: true
         useTemplating: true ## flag to say templating is being used below
@@ -818,16 +817,16 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('PUBCHEM.COMPOUND') | wrap( '["' , '","biolink:has_target"]') }} ],
-              "scopes": ["subject.id", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('PUBCHEM.COMPOUND') | wrap( '["' , '","biolink:physically_interacts_with"]') }} ],
+              "scopes": ["subject.pubchem_compound", "predicate"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,sources
+          fields: object.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
             semantic: Gene
-        predicate: has_target
+        predicate: physically_interacts_with
         response_mapping:
           "$ref": "#/components/x-bte-response-mapping/ncbigene-object"
         # testExamples:
@@ -843,24 +842,23 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:has_target"]') }} ],
-              "scopes": ["object.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:physically_interacts_with"]') }} ],
+              "scopes": ["object.NCBIGene", "predicate"]
             }
         parameters:
-          fields: subject.id,association.edge_attributes,sources
+          fields: subject.pubchem_compound,attributes,sources
           size: 1000
         outputs:
           - id: "PUBCHEM.COMPOUND"
             semantic: SmallMolecule
-        predicate: target_for
+        predicate: physically_interacts_with #change predicate
         response_mapping:
-          "$ref": "#/components/x-bte-response-mapping/pubchem-subject-error"
+          "$ref": "#/components/x-bte-response-mapping/pubchem-subject"
         # testExamples:
         #   - qInput: "NCBIGene:8424"                 ## BBOX1
         #     oneOutput: "PUBCHEM.COMPOUND:5455"      ## Thiram
-## data has errors, so edit this after update
     gene-physicallyInteracts-gene:
-    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=association.edge_label:"biolink:physically_interacts_with"
+    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=predicate:"biolink:physically_interacts_with"
     ##  888994 records  
       - supportBatch: true
         useTemplating: true ## flag to say templating is being used below
@@ -871,11 +869,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:physically_interacts_with"]') }} ],
-              "scopes": ["subject.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:physically_interacts_with"]') }} ],
+              "scopes": ["subject.NCBIGene", "predicate"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,sources
+          fields: object.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -896,11 +894,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:physically_interacts_with"]') }} ],
-              "scopes": ["object.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:physically_interacts_with"]') }} ],
+              "scopes": ["object.NCBIGene", "predicate"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes
+          fields: subject.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -912,7 +910,7 @@ components:
         #   - qInput: "NCBIGene:6874"       ## TAF4
         #     oneOutput: "NCBIGene:6881"    ## TAF10
     gene-geneticallyInteracts-gene:
-    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=association.edge_label:"biolink:genetically_interacts_with"
+    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=predicate:"biolink:genetically_interacts_with"
     ##  10754 records  
       - supportBatch: true
         useTemplating: true ## flag to say templating is being used below
@@ -923,11 +921,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:genetically_interacts_with"]') }} ],
-              "scopes": ["subject.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:genetically_interacts_with"]') }} ],
+              "scopes": ["subject.NCBIGene", "predicate"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,sources
+          fields: object.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -948,11 +946,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:genetically_interacts_with"]') }} ],
-              "scopes": ["object.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:genetically_interacts_with"]') }} ],
+              "scopes": ["object.NCBIGene", "predicate"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,sources
+          fields: subject.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -964,7 +962,7 @@ components:
         #   - qInput: "NCBIGene:2081"         ## ERN1
         #     oneOutput: "NCBIGene:4609"      ## MYC
     gene-negativelyCorrelated-gene:
-    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=association.edge_label:"biolink:negatively_correlated_with"
+    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=predicate:"biolink:negatively_correlated_with"
     ##  565 records  
       - supportBatch: true
         useTemplating: true ## flag to say templating is being used below
@@ -975,11 +973,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:negatively_correlated_with"]') }} ],
-              "scopes": ["subject.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:negatively_correlated_with"]') }} ],
+              "scopes": ["subject.NCBIGene", "predicate"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,sources
+          fields: object.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1000,11 +998,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:negatively_correlated_with"]') }} ],
-              "scopes": ["object.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:negatively_correlated_with"]') }} ],
+              "scopes": ["object.NCBIGene", "predicate"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,sources
+          fields: subject.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1016,7 +1014,7 @@ components:
         #   - qInput: "NCBIGene:6540"         ## SLC6A13
         #     oneOutput: "NCBIGene:1072"      ## CFL1
     gene-positivelyCorrelated-gene:
-    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=association.edge_label:"biolink:positively_correlated_with"
+    ##  https://biothings.ncats.io/biggim_drugresponse_kp/query?q=predicate:"biolink:positively_correlated_with"
     ##  437054 records  
       - supportBatch: true
         useTemplating: true ## flag to say templating is being used below
@@ -1027,11 +1025,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:positively_correlated_with"]') }} ],
-              "scopes": ["subject.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:positively_correlated_with"]') }} ],
+              "scopes": ["subject.NCBIGene", "predicate"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,sources
+          fields: object.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1052,11 +1050,11 @@ components:
         requestBody:
           body: >-
             {
-              "q": [ {{ queryInputs | addPrefix('NCBIGene') | wrap( '["' , '","biolink:positively_correlated_with"]') }} ],
-              "scopes": ["object.NCBIGene", "association.edge_label"]
+              "q": [ {{ queryInputs | replPrefix('NCBIGene') | wrap( '["' , '","biolink:positively_correlated_with"]') }} ],
+              "scopes": ["object.NCBIGene", "predicate"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,sources
+          fields: subject.NCBIGene,attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1070,30 +1068,26 @@ components:
   x-bte-response-mapping:
   ## all have prefix
     pubchem-subject:
-      "PUBCHEM.COMPOUND": subject.PUBCHEM_COMPOUND
-      edge-attributes: association.edge_attributes
+      "PUBCHEM.COMPOUND": subject.pubchem_compound
+      edge-attributes: attributes
       trapi_sources: sources
     pubchem-object:
-      "PUBCHEM.COMPOUND": object.PUBCHEM_COMPOUND
-      edge-attributes: association.edge_attributes
+      "PUBCHEM.COMPOUND": object.pubchem_compound
+      edge-attributes: attributes
       trapi_sources: sources
     ncbigene-subject:
       NCBIGene: subject.NCBIGene
-      edge-attributes: association.edge_attributes
+      edge-attributes: attributes
       trapi_sources: sources
     ncbigene-object:
       NCBIGene: object.NCBIGene
-      edge-attributes: association.edge_attributes
+      edge-attributes: attributes
       trapi_sources: sources
     mondo-subject:
       MONDO: subject.MONDO
-      edge-attributes: association.edge_attributes
+      edge-attributes: attributes
       trapi_sources: sources
     mondo-object:
       MONDO: object.MONDO
-      edge-attributes: association.edge_attributes
-      trapi_sources: sources
-    pubchem-subject-error:
-      "PUBCHEM.COMPOUND": subject.id
-      edge-attributes: association.edge_attributes
+      edge-attributes: attributes
       trapi_sources: sources

--- a/drug_response_kp/smartapi.yaml
+++ b/drug_response_kp/smartapi.yaml
@@ -613,7 +613,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.PUBCHEM_COMPOUND,association.edge_attributes,association.sources
+          fields: object.PUBCHEM_COMPOUND,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: "PUBCHEM.COMPOUND"
@@ -638,7 +638,7 @@ components:
               "scopes": ["object.PUBCHEM_COMPOUND", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,association.sources
+          fields: subject.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -665,7 +665,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.PUBCHEM_COMPOUND,association.edge_attributes,association.sources
+          fields: object.PUBCHEM_COMPOUND,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: "PUBCHEM.COMPOUND"
@@ -690,7 +690,7 @@ components:
               "scopes": ["object.PUBCHEM_COMPOUND", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,association.sources
+          fields: subject.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -717,7 +717,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.MONDO,association.edge_attributes,association.sources
+          fields: object.MONDO,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: MONDO
@@ -742,7 +742,7 @@ components:
               "scopes": ["object.MONDO", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,association.sources
+          fields: subject.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -769,7 +769,7 @@ components:
               "scopes": ["subject.MONDO", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,association.sources
+          fields: object.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -794,7 +794,7 @@ components:
               "scopes": ["object.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: subject.MONDO,association.edge_attributes,association.sources
+          fields: subject.MONDO,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: MONDO
@@ -822,7 +822,7 @@ components:
               "scopes": ["subject.id", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,association.sources
+          fields: object.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -847,7 +847,7 @@ components:
               "scopes": ["object.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: subject.id,association.edge_attributes,association.sources
+          fields: subject.id,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: "PUBCHEM.COMPOUND"
@@ -875,7 +875,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,association.sources
+          fields: object.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -927,7 +927,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,association.sources
+          fields: object.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -952,7 +952,7 @@ components:
               "scopes": ["object.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,association.sources
+          fields: subject.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -979,7 +979,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,association.sources
+          fields: object.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1004,7 +1004,7 @@ components:
               "scopes": ["object.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,association.sources
+          fields: subject.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1031,7 +1031,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes,association.sources
+          fields: object.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1056,7 +1056,7 @@ components:
               "scopes": ["object.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes,association.sources
+          fields: subject.NCBIGene,association.edge_attributes,sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1072,28 +1072,28 @@ components:
     pubchem-subject:
       "PUBCHEM.COMPOUND": subject.PUBCHEM_COMPOUND
       edge-attributes: association.edge_attributes
-      trapi_sources: association.sources
+      trapi_sources: sources
     pubchem-object:
       "PUBCHEM.COMPOUND": object.PUBCHEM_COMPOUND
       edge-attributes: association.edge_attributes
-      trapi_sources: association.sources
+      trapi_sources: sources
     ncbigene-subject:
       NCBIGene: subject.NCBIGene
       edge-attributes: association.edge_attributes
-      trapi_sources: association.sources
+      trapi_sources: sources
     ncbigene-object:
       NCBIGene: object.NCBIGene
       edge-attributes: association.edge_attributes
-      trapi_sources: association.sources
+      trapi_sources: sources
     mondo-subject:
       MONDO: subject.MONDO
       edge-attributes: association.edge_attributes
-      trapi_sources: association.sources
+      trapi_sources: sources
     mondo-object:
       MONDO: object.MONDO
       edge-attributes: association.edge_attributes
-      trapi_sources: association.sources
+      trapi_sources: sources
     pubchem-subject-error:
       "PUBCHEM.COMPOUND": subject.id
       edge-attributes: association.edge_attributes
-      trapi_sources: association.sources
+      trapi_sources: sources

--- a/drug_response_kp/smartapi.yaml
+++ b/drug_response_kp/smartapi.yaml
@@ -613,7 +613,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.PUBCHEM_COMPOUND,association.edge_attributes
+          fields: object.PUBCHEM_COMPOUND,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: "PUBCHEM.COMPOUND"
@@ -638,7 +638,7 @@ components:
               "scopes": ["object.PUBCHEM_COMPOUND", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes
+          fields: subject.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -665,7 +665,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.PUBCHEM_COMPOUND,association.edge_attributes
+          fields: object.PUBCHEM_COMPOUND,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: "PUBCHEM.COMPOUND"
@@ -690,7 +690,7 @@ components:
               "scopes": ["object.PUBCHEM_COMPOUND", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes
+          fields: subject.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -717,7 +717,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.MONDO,association.edge_attributes
+          fields: object.MONDO,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: MONDO
@@ -742,7 +742,7 @@ components:
               "scopes": ["object.MONDO", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes
+          fields: subject.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -769,7 +769,7 @@ components:
               "scopes": ["subject.MONDO", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes
+          fields: object.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -794,7 +794,7 @@ components:
               "scopes": ["object.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: subject.MONDO,association.edge_attributes
+          fields: subject.MONDO,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: MONDO
@@ -822,7 +822,7 @@ components:
               "scopes": ["subject.id", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes
+          fields: object.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -847,7 +847,7 @@ components:
               "scopes": ["object.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: subject.id,association.edge_attributes
+          fields: subject.id,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: "PUBCHEM.COMPOUND"
@@ -875,7 +875,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes
+          fields: object.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -927,7 +927,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes
+          fields: object.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -952,7 +952,7 @@ components:
               "scopes": ["object.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes
+          fields: subject.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -979,7 +979,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes
+          fields: object.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1004,7 +1004,7 @@ components:
               "scopes": ["object.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes
+          fields: subject.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1031,7 +1031,7 @@ components:
               "scopes": ["subject.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: object.NCBIGene,association.edge_attributes
+          fields: object.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1056,7 +1056,7 @@ components:
               "scopes": ["object.NCBIGene", "association.edge_label"]
             }
         parameters:
-          fields: subject.NCBIGene,association.edge_attributes
+          fields: subject.NCBIGene,association.edge_attributes,association.sources
           size: 1000
         outputs:
           - id: NCBIGene
@@ -1072,21 +1072,28 @@ components:
     pubchem-subject:
       "PUBCHEM.COMPOUND": subject.PUBCHEM_COMPOUND
       edge-attributes: association.edge_attributes
+      trapi_sources: association.sources
     pubchem-object:
       "PUBCHEM.COMPOUND": object.PUBCHEM_COMPOUND
       edge-attributes: association.edge_attributes
+      trapi_sources: association.sources
     ncbigene-subject:
       NCBIGene: subject.NCBIGene
       edge-attributes: association.edge_attributes
+      trapi_sources: association.sources
     ncbigene-object:
       NCBIGene: object.NCBIGene
       edge-attributes: association.edge_attributes
+      trapi_sources: association.sources
     mondo-subject:
       MONDO: subject.MONDO
       edge-attributes: association.edge_attributes
+      trapi_sources: association.sources
     mondo-object:
       MONDO: object.MONDO
       edge-attributes: association.edge_attributes
+      trapi_sources: association.sources
     pubchem-subject-error:
       "PUBCHEM.COMPOUND": subject.id
       edge-attributes: association.edge_attributes
+      trapi_sources: association.sources


### PR DESCRIPTION
WAIT: only merge once BTE is migrating to have all instances TRAPI 1.4. In this process, the overrides will be removed - so BTE will use the registered yamls for these KPs. So merging this PR will get these registered yamls updated. Then we want to refresh the registration. 


