### PR TITLE
Update MolePro-TRAPI-1.4.yaml

### DIFF
--- a/molecular_data_provider/MolePro-TRAPI-1.4.yaml
+++ b/molecular_data_provider/MolePro-TRAPI-1.4.yaml
@@ -38,6 +38,9 @@ info:
       url: https://github.com/NCATSTranslator/translator_extensions/blob/\
         production/x-trapi/
 servers:
+  - url: https://molepro-trapi.transltr.io/molepro/trapi/v1.4
+    description: TRAPI production service for MolePro
+    x-maturity: production
   - url: https://molepro-trapi.test.transltr.io/molepro/trapi/v1.4
     description: TRAPI test service for MolePro
     x-maturity: testing


### PR DESCRIPTION
To refresh our smart api registration, added the URL to the MolePro TRAPI 1.4. hosted on the  NCATS Production server