### PR TITLE
update ORPHANET -> orphanet

### DIFF
--- a/complexportal/smartapi.yaml
+++ b/complexportal/smartapi.yaml
@@ -109,7 +109,7 @@ components:
     - supportBatch: false
       useTemplating: true
       inputs:
-      - id: ORPHANET
+      - id: orphanet
         semantic: Disease
       outputs:
       - id: ComplexPortal
@@ -122,7 +122,7 @@ components:
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/complex-output"
       # testExamples:
-      #   - qInput: "ORPHANET:848"                 ## Beta-thalassemia
+      #   - qInput: "orphanet:848"                 ## Beta-thalassemia
       #     oneOutput: "ComplexPortal:CPX-2158"    ## Hemoglobin HbA complex
     ## Complex -> entity x-bte operations use JQ post-processing
     # complex2protein:
@@ -172,7 +172,7 @@ components:
     #   - id: ComplexPortal
     #     semantic: MacromolecularComplex
     #   outputs:
-    #   - id: ORPHANET
+    #   - id: orphanet
     #     semantic: Disease
     #   parameters:
     #     id: "{{ queryInputs }}" ## no prefix
@@ -187,7 +187,7 @@ components:
     #     "$ref": "#/components/x-bte-response-mapping/complex2disease"
     #   # testExamples:
     #   #   - qInput: "ComplexPortal:CPX-2158"      ## Hemoglobin HbA complex
-    #   #     oneOutput: "ORPHANET:848"             ## Beta-thalassemia
+    #   #     oneOutput: "orphanet:848"             ## Beta-thalassemia
   x-bte-response-mapping:
     complex-output:
       ComplexPortal: elements.complexAC
@@ -203,5 +203,5 @@ components:
       CHEBI: participants.identifier
     complex2disease:
       ## this is a field made with JQ-post-processing
-      ORPHANET: disease_ids
+      orphanet: disease_ids
    

--- a/mydisease.info/smartapi.yaml
+++ b/mydisease.info/smartapi.yaml
@@ -661,7 +661,7 @@ components:
     omim:
       OMIM: hpo.omim  ## no prefix
     orphanet:
-      ORPHANET: hpo.orphanet  ## no prefix
+      orphanet: hpo.orphanet  ## no prefix
     mondo:  ## added for a bunch of operations
       MONDO: mondo.mondo  ## HAS PREFIX (MONDO)
     ctd-mesh-disease:  ## added for chemical-disease operation
@@ -827,7 +827,7 @@ components:
       - supportBatch: true
         useTemplating: true
         inputs:
-        - id: ORPHANET
+        - id: orphanet
           semantic: Disease
         requestBody:
           body:
@@ -870,7 +870,7 @@ components:
         response_mapping:
           "$ref": "#/components/x-bte-response-mapping/disease-phenotype"
         # testExamples:
-        #   - qInput: "ORPHANET:881"    ## Turner Syndrome
+        #   - qInput: "orphanet:881"    ## Turner Syndrome
         #     oneOutput: "HP:0000137"   ## Abnormality of the ovary
   ## for ctd-based operations:
   ## - when the mydisease parser maps the resources' IDs to MONDO, are there situations where a MESH and a OMIM ID map to the same MONDO? 
@@ -1038,7 +1038,7 @@ components:
             q: "{{ queryInputs }}"
             scopes: hpo.phenotype_related_to_disease.hpo_id
         outputs:
-        - id: ORPHANET
+        - id: orphanet
           semantic: Disease
         parameters:
           fields: hpo.orphanet
@@ -1049,7 +1049,7 @@ components:
           "$ref": "#/components/x-bte-response-mapping/orphanet"
         # testExamples:
         #   - qInput: "HP:0000224"          ## Hypogeusia
-        #     oneOutput: "ORPHANET:99857"   ## Secondary Syringomyelia
+        #     oneOutput: "orphanet:99857"   ## Secondary Syringomyelia
     chemical-disease:
       - supportBatch: true
         useTemplating: true

--- a/ncats_rare_source/smartapi.yaml
+++ b/ncats_rare_source/smartapi.yaml
@@ -599,7 +599,7 @@ components:
           q: "{{ queryInputs }}"   ## no prefix
           scopes: entrezgene
       outputs:
-      - id: ORPHANET
+      - id: orphanet
         semantic: Disease
       parameters:
       ## orphanet ID has no prefix
@@ -611,12 +611,12 @@ components:
         "$ref": "#/components/x-bte-response-mapping/diseaseOrphanet-object"
       # testExamples:
       #   - qInput: "NCBIGene:100"           ## ADA
-      #     oneOutput: "ORPHANET:39041"      ## Omenn syndrome
+      #     oneOutput: "orphanet:39041"      ## Omenn syndrome
     diseaseOrphanet-gene:
     - supportBatch: true
       useTemplating: true
       inputs:
-      - id: ORPHANET
+      - id: orphanet
         semantic: Disease
       requestBody:
         body:
@@ -635,7 +635,7 @@ components:
       response_mapping:
         "$ref": "#/components/x-bte-response-mapping/gene-object"
       # testExamples:
-      #   - qInput: "ORPHANET:110"          ## Bardet-Biedl syndrome
+      #   - qInput: "orphanet:110"          ## Bardet-Biedl syndrome
       #     oneOutput: "NCBIGene:10806"    ## SDCCAG8
     gene-diseaseUMLS:
     - supportBatch: true
@@ -692,7 +692,7 @@ components:
   ## didn't add names for gene -> disease. when I tried, the co-occurrence urls would appear on every Edge, 
   ##   when they're supposed to show up only on the edge they correspond to
     diseaseOrphanet-object:
-      ORPHANET: raresource.disease.orphanet    ## no prefix
+      orphanet: raresource.disease.orphanet    ## no prefix
       ref_url: raresource.disease.cooccurrence_url
       ## this url leads to a webpage with literature supporting the gene-disease relationship 
     diseaseUMLS-object:


### PR DESCRIPTION
Don't merge this PR until all instances of NodeNorm (especially Prod) has updated to change ORPHANET -> orphanet in their responses. 

Addresses https://github.com/biothings/biothings_explorer/issues/640#issuecomment-1840096656

In the meantime, we'll use overrides from https://github.com/biothings/bte-server/pull/4 and https://github.com/biothings/bte-server/commit/28e5b58938769616cc37aae303d1935eabde5eab, so keep this branch and these yamls up-to-date until the overrides are removed from all instances. 