### PR TITLE
update BTE/service-provider yamls for TRAPI 1.5

### DIFF
--- a/biothings_explorer/service-provider-trapi.yaml
+++ b/biothings_explorer/service-provider-trapi.yaml
@@ -41,6 +41,9 @@ info:
         - "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/biothings_explorer/sri-test-multiomics.json"
         - "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/biothings_explorer/sri-test-text-mining.json"
 servers:
+- url: https://bte.transltr.io/v1/team/Service%20Provider
+  description: ITRB Production server
+  x-maturity: production
 - url: https://bte.test.transltr.io/v1/team/Service%20Provider
   description: ITRB Test server
   x-maturity: testing

--- a/biothings_explorer/service-provider-trapi.yaml
+++ b/biothings_explorer/service-provider-trapi.yaml
@@ -22,6 +22,8 @@ info:
     infores: "infores:service-provider-trapi"
   x-trapi:
     version: "1.5.0"
+    multicuriequery: false
+    pathfinderquery: false   ## BTE-ARA endpoints only
     asyncquery: true
     operations:
     ## look at https://standards.ncats.io/operation.json for details. 
@@ -394,8 +396,10 @@ components:
   ## - AsyncQuery: callback property not required (commented it out of the 'required' field),
   ##               comment out workflow.oneOf section
   ## - Response: comment out workflow.oneOf section
-  ## - Attribute: comment out properties.attributes.items since the self-$ref breaks execution of 
-  ##              BTE's api-schema-builder/openapi-validator-middleware
+  ## - Attribute: comment out type and items. The self-$ref in items breaks BTE, because
+  ##              an error occurs in its api-schema-builder/openapi-validator-middleware.
+  ##              The type is commented out because there'd be a semantic error for
+  ##              specifying an array without items. 
   schemas:
     Query:
       description: >-
@@ -443,7 +447,9 @@ components:
             Set to true in order to request that the agent obtain
             fresh information from its sources in all cases where
             it has a viable choice between requesting fresh information
-            in real time and using cached information.
+            in real time and using cached information. The agent
+            receiving this flag MUST also include it in TRAPI sent to
+            downstream sources (e.g., ARS -> ARAs -> KPs).
       additionalProperties: true
       required:
         - message
@@ -502,7 +508,9 @@ components:
             Set to true in order to request that the agent obtain
             fresh information from its sources in all cases where
             it has a viable choice between requesting fresh information
-            in real time and using cached information.
+            in real time and using cached information. The agent
+            receiving this flag MUST also include it in TRAPI sent to
+            downstream sources (e.g., ARS -> ARAs -> KPs).
       additionalProperties: true
       required:
       ## BTE does not require the callback property, see the asyncquery
@@ -1014,8 +1022,20 @@ components:
           items:
             $ref: '#/components/schemas/CURIE'
           minItems: 1
-          example: [OMIM:603903]
-          description: CURIE identifier for this node
+          example: ["OMIM:603903"]
+          description: >-
+            A CURIE identifier (or list of identifiers) for this node. 
+            The 'ids' field will hold a list of CURIEs only in the case of a
+            BATCH set_interpretation, where each CURIE is queried 
+            separately. If a list of queried CURIEs is to be considered as a  
+            set (as under a MANY or ALL set_interpretation), the 'ids' field 
+            will hold a single id representing this set, and the individual members 
+            of this set will be captured in a separate 'member_ids' field. 
+            Note that the set id MUST be created as a UUID by the system that 
+            defines the queried set, using a centralized nodenorm service. 
+            Note also that downstream systems MUST re-use the original set UUID 
+            in the messages they create/send, which will facilitate merging or 
+            caching operations.
           nullable: true
         categories:
           type: array
@@ -1043,6 +1063,17 @@ components:
             - ALL
             - MANY
           nullable: true
+        member_ids:
+          type: array
+          description: >-
+            A list of CURIE identifiers for members of a queried set. This 
+            field MUST be populated under a set_interpretation of MANY
+            or ALL, when the 'ids' field holds a UUID representing the set 
+            itself. This field MUST NOT be used under a set_interpretation 
+            of BATCH.
+          nullable: true
+          items:
+            $ref: '#/components/schemas/CURIE'
         constraints:
           type: array
           description: >-
@@ -1242,7 +1273,7 @@ components:
           example: Assertion Authored By Dr. Trans L. Ator
           nullable: true
         attributes:
-          type: array
+          # type: array
           description: >-
             A list of attributes providing further information about the
             parent attribute (for example to provide provenance
@@ -1710,7 +1741,7 @@ components:
             an Edge provided by the ARAGORN ARA can expressing knowledge it
             retrieved from both the automat-mychem-info and molepro KPs,
             which both provided it with records of this single fact.
-          example: [infores:automat-mychem-info, infores:molepro]
+          example: ["infores:automat-mychem-info", "infores:molepro"]
         source_record_urls:
           type: array
           nullable: true

--- a/biothings_explorer/service-provider-trapi.yaml
+++ b/biothings_explorer/service-provider-trapi.yaml
@@ -21,7 +21,7 @@ info:
     biolink-version: "4.1.6"
     infores: "infores:service-provider-trapi"
   x-trapi:
-    version: 1.5.0-beta
+    version: "1.5.0"
     asyncquery: true
     operations:
     ## look at https://standards.ncats.io/operation.json for details. 
@@ -39,6 +39,9 @@ info:
         - "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/biothings_explorer/sri-test-multiomics.json"
         - "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/biothings_explorer/sri-test-text-mining.json"
 servers:
+- url: https://bte.test.transltr.io/v1/team/Service%20Provider
+  description: ITRB Test server
+  x-maturity: testing
 - url: https://bte.ci.transltr.io/v1/team/Service%20Provider
   description: ITRB CI server
   x-maturity: staging
@@ -46,7 +49,7 @@ servers:
   description: Non-ITRB dev (internal use)
   x-maturity: development
 tags:
-- name: 1.5.0-beta
+- name: "1.5.0"
 - name: meta_knowledge_graph
 - name: query
 - name: asyncquery

--- a/biothings_explorer/service-provider-trapi.yaml
+++ b/biothings_explorer/service-provider-trapi.yaml
@@ -18,7 +18,7 @@ info:
     component: KP
     team:
       - Service Provider
-    biolink-version: "3.5.3"
+    biolink-version: "4.1.6"
     infores: "infores:service-provider-trapi"
   x-trapi:
     version: 1.5.0-beta

--- a/biothings_explorer/service-provider-trapi.yaml
+++ b/biothings_explorer/service-provider-trapi.yaml
@@ -21,11 +21,10 @@ info:
     biolink-version: "3.5.3"
     infores: "infores:service-provider-trapi"
   x-trapi:
-    version: 1.4.0
+    version: 1.5.0-beta
     asyncquery: true
     operations:
     ## look at https://standards.ncats.io/operation.json for details. 
-    ## could use lookup_and_score in the future?
       - lookup
     ## /query endpoints have a limit of 15 requests/client/min
     ## /meta_knowledge_graph endpoints have a limit of 30 requests/client/min
@@ -40,12 +39,6 @@ info:
         - "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/biothings_explorer/sri-test-multiomics.json"
         - "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/biothings_explorer/sri-test-text-mining.json"
 servers:
-- url: https://bte.transltr.io/v1/team/Service%20Provider
-  description: ITRB Production server
-  x-maturity: production
-- url: https://bte.test.transltr.io/v1/team/Service%20Provider
-  description: ITRB Test server
-  x-maturity: testing
 - url: https://bte.ci.transltr.io/v1/team/Service%20Provider
   description: ITRB CI server
   x-maturity: staging
@@ -53,7 +46,7 @@ servers:
   description: Non-ITRB dev (internal use)
   x-maturity: development
 tags:
-- name: 1.4.0
+- name: 1.5.0-beta
 - name: meta_knowledge_graph
 - name: query
 - name: asyncquery
@@ -339,7 +332,9 @@ components:
       type: object
       properties:
         message:
-          $ref: '#/components/schemas/Message'
+          oneOf:
+            - $ref: '#/components/schemas/Message'
+          nullable: false
           description: >-
             The query Message is a serialization of the user request. Content
             of the Message object depends on the intended TRAPI operation. For
@@ -354,7 +349,7 @@ components:
         workflow:
           description: List of workflow steps to be executed.
           # oneOf:
-          #   - $ref: http://standards.ncats.io/workflow/1.3.4/schema
+          #   - $ref: https://standards.ncats.io/workflow/1.3.5/schema
           nullable: true
         submitter:
           type: string
@@ -363,6 +358,14 @@ components:
             purpose of this optional field is to aid in the tracking of
             the source of queries for development and issue resolution.
           nullable: true
+        bypass_cache:
+          type: boolean
+          default: false
+          description: >-
+            Set to true in order to request that the agent obtain
+            fresh information from its sources in all cases where
+            it has a viable choice between requesting fresh information
+            in real time and using cached information.
       additionalProperties: true
       required:
         - message
@@ -375,6 +378,7 @@ components:
       properties:
         callback:
           type: string
+          nullable: false
           format: uri
           pattern: ^https?://
           description: >-
@@ -387,7 +391,9 @@ components:
             does not succeed, the server SHOULD retry the POST at least
             once.
         message:
-          $ref: '#/components/schemas/Message'
+          oneOf:
+            - $ref: '#/components/schemas/Message'
+          nullable: false
           description: >-
             The query Message is a serialization of the user request. Content
             of the Message object depends on the intended TRAPI operation. For
@@ -402,7 +408,7 @@ components:
         workflow:
           description: List of workflow steps to be executed.
           # oneOf:
-          #   - $ref: http://standards.ncats.io/workflow/1.3.4/schema
+          #   - $ref: https://standards.ncats.io/workflow/1.3.5/schema
           nullable: true
         submitter:
           type: string
@@ -411,6 +417,14 @@ components:
             purpose of this optional field is to aid in the tracking of
             the source of queries for development and issue resolution.
           nullable: true
+        bypass_cache:
+          type: boolean
+          default: false
+          description: >-
+            Set to true in order to request that the agent obtain
+            fresh information from its sources in all cases where
+            it has a viable choice between requesting fresh information
+            in real time and using cached information.
       additionalProperties: true
       required:
       ## BTE does not require the callback property, see the asyncquery
@@ -478,6 +492,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LogEntry'
+          minItems: 1
           nullable: false
         response_url:
           description: >-
@@ -505,7 +520,9 @@ components:
           description: >-
             Contains the knowledge of the response (query graph, knowledge
             graph, and results).
-          $ref: '#/components/schemas/Message'
+          oneOf:
+            - $ref: '#/components/schemas/Message'
+          nullable: false
         status:
           description: >-
             One of a standardized set of short codes,
@@ -526,20 +543,23 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LogEntry'
-          nullable: true
+          minItems: 0
+          nullable: false
         workflow:
           description: List of workflow steps that were executed.
           # oneOf:
-          #   - $ref: http://standards.ncats.io/workflow/1.3.4/schema
+          #   - $ref: https://standards.ncats.io/workflow/1.3.5/schema
           nullable: true
         schema_version:
           type: string
           example: 1.4.0
           description: Version label of the TRAPI schema used in this document
+          nullable: true
         biolink_version:
           type: string
           example: 3.1.2
           description: Version label of the Biolink model used in this document
+          nullable: true
       additionalProperties: true
       required:
         - message
@@ -559,11 +579,16 @@ components:
           description: >-
             List of all returned Result objects for the query posed.
             The list SHOULD NOT be assumed to be ordered. The 'score' property,
-             if present, MAY be used to infer result rankings.
+            if present, MAY be used to infer result rankings. If Results are
+            not expected (such as for a query Message), this property SHOULD
+            be null or absent. If Results are expected (such as for a response
+            Message) and no Results are available, this property SHOULD be an
+            array with 0 Results in it.
           type: array
           items:
             $ref: '#/components/schemas/Result'
           nullable: true
+          minItems: 0
         query_graph:
           description: >-
             QueryGraph object that contains a serialization of a query in the
@@ -659,6 +684,8 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/NodeBinding'
+            minItems: 1
+          nullable: false 
         analyses:
           type: array
           description: >-
@@ -666,6 +693,8 @@ components:
             See below for Analysis components.
           items:
             $ref: '#/components/schemas/Analysis'
+          minItems: 0
+          nullable: false 
       additionalProperties: true
       required:
         - node_bindings
@@ -681,7 +710,9 @@ components:
           Binding must bind directly to node in the original Query Graph.
       properties:
         id:
-          $ref: '#/components/schemas/CURIE'
+          oneOf:
+            - $ref: '#/components/schemas/CURIE'
+          nullable: false
           description: >-
             The CURIE of a Node within the Knowledge Graph.
         query_id:
@@ -707,10 +738,12 @@ components:
             result.
           items:
             $ref: '#/components/schemas/Attribute'
-          nullable: true
+          minItems: 0
+          nullable: false
       additionalProperties: true
       required:
         - id
+        - attributes
     Analysis:
       type: object
       description: >-
@@ -788,6 +821,7 @@ components:
         id:
           type: string
           description: The key identifier of a specific KnowledgeGraph Edge.
+          nullable: false
         attributes:
           type: array
           description: >-
@@ -797,10 +831,12 @@ components:
             result.
           items:
             $ref: '#/components/schemas/Attribute'
-          nullable: true
+          minItems: 0
+          nullable: false
       additionalProperties: true
       required:
         - id
+        - attributes
     AuxiliaryGraph:
       type: object
       description: >-
@@ -827,10 +863,12 @@ components:
             Attributes of the Auxiliary Graph
           items:
             $ref: '#/components/schemas/Attribute'
-          nullable: true
+          minItems: 0
+          nullable: false
       additionalProperties: true
       required:
         - edges
+        - attributes
     KnowledgeGraph:
       type: object
       description: >-
@@ -911,20 +949,22 @@ components:
             $ref: '#/components/schemas/BiolinkEntity'
           minItems: 1
           nullable: true
-        is_set:
-          type: boolean
+        set_interpretation:
+          type: string
           description: >-
-            Boolean that if set to true, indicates that this QNode MAY have
-            multiple KnowledgeGraph Nodes bound to it within each Result.
-            The nodes in a set should be considered as a set of independent
-            nodes, rather than a set of dependent nodes, i.e., the answer
-            would still be valid if the nodes in the set were instead returned
-            individually. Multiple QNodes may have is_set=True. If a QNode
-            (n1) with is_set=True is connected to a QNode (n2) with
-            is_set=False, each n1 must be connected to n2. If a QNode (n1)
-            with is_set=True is connected to a QNode (n2) with is_set=True,
-            each n1 must be connected to at least one n2.
-          default: false
+            Indicates how multiple CURIEs in the ids property MUST be
+            interpreted. BATCH indicates that the query is intended to be
+            a batch query and each CURIE is treated independently. ALL means
+            that all specified CURIES MUST appear in each Result.
+            MANY means that member CURIEs MUST form one or more
+            sets in the Results, and sets with more members are generally
+            considered more desirable that sets with fewer members.
+            If this property is missing or null, the default is BATCH.
+          enum:
+            - BATCH
+            - ALL
+            - MANY
+          nullable: true
         constraints:
           type: array
           description: >-
@@ -1030,13 +1070,25 @@ components:
             categories should also be avoided.
           items:
             $ref: '#/components/schemas/BiolinkEntity'
-          nullable: true
+          minItems: 1
+          nullable: false
         attributes:
           type: array
           description: A list of attributes describing the node
           items:
             $ref: '#/components/schemas/Attribute'
-          nullable: true
+          minItems: 0
+          nullable: false
+        is_set:
+          type: boolean
+          description: >-
+            Indicates that the node represents a set of entities.
+            If this property is missing or null, it is assumed to be
+            false.
+          nullable: true        
+      required:
+        - categories
+        - attributes
       additionalProperties: false
     Attribute:
       type: object

--- a/biothings_explorer/service-provider-trapi.yaml
+++ b/biothings_explorer/service-provider-trapi.yaml
@@ -278,6 +278,22 @@ paths:
   #         required: true
   #         schema:
   #           type: string
+  #       - description: >-
+  #           When specified, the TRAPI logs returned will be of this level of importance or higher. This setting
+  #           will override the log_level setting in the job's TRAPI query.
+
+  #           If it's not specified, BTE will use the log_level setting in the job's TRAPI query or return all logs
+  #           (the default). 
+  #         in: query
+  #         name: log_level
+  #         required: false
+  #         schema:
+  #           type: string
+  #           enum:
+  #             - ERROR
+  #             - WARNING
+  #             - INFO
+  #             - DEBUG
   #     responses:
   #       '200':
   #         description: >-
@@ -318,6 +334,22 @@ paths:
   #         required: true
   #         schema:
   #           type: string
+  #       - description: >-
+  #           When specified, the TRAPI logs returned will be of this level of importance or higher. This setting
+  #           will override the log_level setting in the job's TRAPI query.
+
+  #           If it's not specified, BTE will use the log_level setting in the job's TRAPI query or return all logs
+  #           (the default). 
+  #         in: query
+  #         name: log_level
+  #         required: false
+  #         schema:
+  #           type: string
+  #           enum:
+  #             - ERROR
+  #             - WARNING
+  #             - INFO
+  #             - DEBUG
   #     responses:
   #       '200':
   #         description: >-

--- a/biothings_explorer/smartapi.yaml
+++ b/biothings_explorer/smartapi.yaml
@@ -741,6 +741,22 @@ paths:
           required: true
           schema:
             type: string
+        - description: >-
+            When specified, the TRAPI logs returned will be of this level of importance or higher. This setting
+            will override the log_level setting in the job's TRAPI query.
+
+            If it's not specified, BTE will use the log_level setting in the job's TRAPI query or return all logs
+            (the default). 
+          in: query
+          name: log_level
+          required: false
+          schema:
+            type: string
+            enum:
+              - ERROR
+              - WARNING
+              - INFO
+              - DEBUG
       responses:
         '200':
           description: >-
@@ -781,6 +797,22 @@ paths:
           required: true
           schema:
             type: string
+        - description: >-
+            When specified, the TRAPI logs returned will be of this level of importance or higher. This setting
+            will override the log_level setting in the job's TRAPI query.
+
+            If it's not specified, BTE will use the log_level setting in the job's TRAPI query or return all logs
+            (the default). 
+          in: query
+          name: log_level
+          required: false
+          schema:
+            type: string
+            enum:
+              - ERROR
+              - WARNING
+              - INFO
+              - DEBUG
       responses:
         '200':
           description: >-

--- a/biothings_explorer/smartapi.yaml
+++ b/biothings_explorer/smartapi.yaml
@@ -36,6 +36,9 @@ servers:
 ## ITRB CI / staging deployments are made by our team.
 ## non-ITRB dev deployments are made by our team.
 ##   We have full control on when / what branches for modules are used
+- url: https://bte.transltr.io/v1
+  description: ITRB Production server
+  x-maturity: production
 - url: https://bte.test.transltr.io/v1
   description: ITRB Test server
   x-maturity: testing

--- a/biothings_explorer/smartapi.yaml
+++ b/biothings_explorer/smartapi.yaml
@@ -16,6 +16,8 @@ info:
     infores: "infores:biothings-explorer"
   x-trapi:
     version: "1.5.0"
+    multicuriequery: false
+    pathfinderquery: true  ## dev instance only
     asyncquery: true
     operations:
     ## look at https://standards.ncats.io/operation.json for details.
@@ -876,8 +878,10 @@ components:
   ## - AsyncQuery: callback property not required (commented it out of the 'required' field),
   ##               comment out workflow.oneOf section
   ## - Response: comment out workflow.oneOf section
-  ## - Attribute: comment out properties.attributes.items since the self-$ref breaks execution of 
-  ##              BTE's api-schema-builder/openapi-validator-middleware
+  ## - Attribute: comment out type and items. The self-$ref in items breaks BTE, because
+  ##              an error occurs in its api-schema-builder/openapi-validator-middleware.
+  ##              The type is commented out because there'd be a semantic error for
+  ##              specifying an array without items. 
   schemas:
     Query:
       description: >-
@@ -925,7 +929,9 @@ components:
             Set to true in order to request that the agent obtain
             fresh information from its sources in all cases where
             it has a viable choice between requesting fresh information
-            in real time and using cached information.
+            in real time and using cached information. The agent
+            receiving this flag MUST also include it in TRAPI sent to
+            downstream sources (e.g., ARS -> ARAs -> KPs).
       additionalProperties: true
       required:
         - message
@@ -984,7 +990,9 @@ components:
             Set to true in order to request that the agent obtain
             fresh information from its sources in all cases where
             it has a viable choice between requesting fresh information
-            in real time and using cached information.
+            in real time and using cached information. The agent
+            receiving this flag MUST also include it in TRAPI sent to
+            downstream sources (e.g., ARS -> ARAs -> KPs).
       additionalProperties: true
       required:
       ## BTE does not require the callback property, see the asyncquery
@@ -1496,8 +1504,20 @@ components:
           items:
             $ref: '#/components/schemas/CURIE'
           minItems: 1
-          example: [OMIM:603903]
-          description: CURIE identifier for this node
+          example: ["OMIM:603903"]
+          description: >-
+            A CURIE identifier (or list of identifiers) for this node. 
+            The 'ids' field will hold a list of CURIEs only in the case of a
+            BATCH set_interpretation, where each CURIE is queried 
+            separately. If a list of queried CURIEs is to be considered as a  
+            set (as under a MANY or ALL set_interpretation), the 'ids' field 
+            will hold a single id representing this set, and the individual members 
+            of this set will be captured in a separate 'member_ids' field. 
+            Note that the set id MUST be created as a UUID by the system that 
+            defines the queried set, using a centralized nodenorm service. 
+            Note also that downstream systems MUST re-use the original set UUID 
+            in the messages they create/send, which will facilitate merging or 
+            caching operations.
           nullable: true
         categories:
           type: array
@@ -1525,6 +1545,17 @@ components:
             - ALL
             - MANY
           nullable: true
+        member_ids:
+          type: array
+          description: >-
+            A list of CURIE identifiers for members of a queried set. This 
+            field MUST be populated under a set_interpretation of MANY
+            or ALL, when the 'ids' field holds a UUID representing the set 
+            itself. This field MUST NOT be used under a set_interpretation 
+            of BATCH.
+          nullable: true
+          items:
+            $ref: '#/components/schemas/CURIE'
         constraints:
           type: array
           description: >-
@@ -1724,7 +1755,7 @@ components:
           example: Assertion Authored By Dr. Trans L. Ator
           nullable: true
         attributes:
-          type: array
+          # type: array
           description: >-
             A list of attributes providing further information about the
             parent attribute (for example to provide provenance
@@ -2192,7 +2223,7 @@ components:
             an Edge provided by the ARAGORN ARA can expressing knowledge it
             retrieved from both the automat-mychem-info and molepro KPs,
             which both provided it with records of this single fact.
-          example: [infores:automat-mychem-info, infores:molepro]
+          example: ["infores:automat-mychem-info", "infores:molepro"]
         source_record_urls:
           type: array
           nullable: true

--- a/biothings_explorer/smartapi.yaml
+++ b/biothings_explorer/smartapi.yaml
@@ -15,7 +15,7 @@ info:
     biolink-version: "4.1.6"
     infores: "infores:biothings-explorer"
   x-trapi:
-    version: 1.5.0-beta
+    version: "1.5.0"
     asyncquery: true
     operations:
     ## look at https://standards.ncats.io/operation.json for details.
@@ -34,6 +34,9 @@ servers:
 ## ITRB CI / staging deployments are made by our team.
 ## non-ITRB dev deployments are made by our team.
 ##   We have full control on when / what branches for modules are used
+- url: https://bte.test.transltr.io/v1
+  description: ITRB Test server
+  x-maturity: testing
 - url: https://bte.ci.transltr.io/v1
   description: ITRB CI server
   x-maturity: staging
@@ -41,7 +44,7 @@ servers:
   description: Non-ITRB dev (internal use)
   x-maturity: development
 tags:
-- name: 1.5.0-beta
+- name: "1.5.0"
 - name: meta_knowledge_graph
 - name: query
 - name: asyncquery

--- a/biothings_explorer/smartapi.yaml
+++ b/biothings_explorer/smartapi.yaml
@@ -12,7 +12,7 @@ info:
     component: ARA
     team:
       - Exploring Agent
-    biolink-version: "3.5.3"
+    biolink-version: "4.1.6"
     infores: "infores:biothings-explorer"
   x-trapi:
     version: 1.5.0-beta

--- a/biothings_explorer/smartapi.yaml
+++ b/biothings_explorer/smartapi.yaml
@@ -15,12 +15,11 @@ info:
     biolink-version: "3.5.3"
     infores: "infores:biothings-explorer"
   x-trapi:
-    version: 1.4.0
+    version: 1.5.0-beta
     asyncquery: true
     operations:
     ## look at https://standards.ncats.io/operation.json for details.
-    ## could use lookup_and_score in the future?
-      - lookup
+      - lookup_and_score
     ## /query endpoints have a limit of 15 requests/client/min
     ## /meta_knowledge_graph endpoints have a limit of 30 requests/client/min
     ## other endpoints don't have rate limits
@@ -34,12 +33,6 @@ servers:
 ## ITRB CI / staging deployments are made by our team (will add details later)
 ## non-ITRB dev: deployments are made by our team
 ##               we have full control on when / what branches for modules are used
-- url: https://bte.transltr.io/v1
-  description: ITRB Production server
-  x-maturity: production
-- url: https://bte.test.transltr.io/v1
-  description: ITRB Test server
-  x-maturity: testing
 - url: https://bte.ci.transltr.io/v1
   description: ITRB CI server
   x-maturity: staging
@@ -47,7 +40,7 @@ servers:
   description: Non-ITRB dev (internal use)
   x-maturity: development
 tags:
-- name: 1.4.0
+- name: 1.5.0-beta
 - name: meta_knowledge_graph
 - name: query
 - name: asyncquery
@@ -822,7 +815,9 @@ components:
       type: object
       properties:
         message:
-          $ref: '#/components/schemas/Message'
+          oneOf:
+            - $ref: '#/components/schemas/Message'
+          nullable: false
           description: >-
             The query Message is a serialization of the user request. Content
             of the Message object depends on the intended TRAPI operation. For
@@ -837,7 +832,7 @@ components:
         workflow:
           description: List of workflow steps to be executed.
           # oneOf:
-          #   - $ref: http://standards.ncats.io/workflow/1.3.4/schema
+          #   - $ref: https://standards.ncats.io/workflow/1.3.5/schema
           nullable: true
         submitter:
           type: string
@@ -846,6 +841,14 @@ components:
             purpose of this optional field is to aid in the tracking of
             the source of queries for development and issue resolution.
           nullable: true
+        bypass_cache:
+          type: boolean
+          default: false
+          description: >-
+            Set to true in order to request that the agent obtain
+            fresh information from its sources in all cases where
+            it has a viable choice between requesting fresh information
+            in real time and using cached information.
       additionalProperties: true
       required:
         - message
@@ -858,6 +861,7 @@ components:
       properties:
         callback:
           type: string
+          nullable: false
           format: uri
           pattern: ^https?://
           description: >-
@@ -870,7 +874,9 @@ components:
             does not succeed, the server SHOULD retry the POST at least
             once.
         message:
-          $ref: '#/components/schemas/Message'
+          oneOf:
+            - $ref: '#/components/schemas/Message'
+          nullable: false
           description: >-
             The query Message is a serialization of the user request. Content
             of the Message object depends on the intended TRAPI operation. For
@@ -885,7 +891,7 @@ components:
         workflow:
           description: List of workflow steps to be executed.
           # oneOf:
-          #   - $ref: http://standards.ncats.io/workflow/1.3.4/schema
+          #   - $ref: https://standards.ncats.io/workflow/1.3.5/schema
           nullable: true
         submitter:
           type: string
@@ -894,6 +900,14 @@ components:
             purpose of this optional field is to aid in the tracking of
             the source of queries for development and issue resolution.
           nullable: true
+        bypass_cache:
+          type: boolean
+          default: false
+          description: >-
+            Set to true in order to request that the agent obtain
+            fresh information from its sources in all cases where
+            it has a viable choice between requesting fresh information
+            in real time and using cached information.
       additionalProperties: true
       required:
       ## BTE does not require the callback property, see the asyncquery
@@ -961,6 +975,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LogEntry'
+          minItems: 1
           nullable: false
         response_url:
           description: >-
@@ -988,7 +1003,9 @@ components:
           description: >-
             Contains the knowledge of the response (query graph, knowledge
             graph, and results).
-          $ref: '#/components/schemas/Message'
+          oneOf:
+            - $ref: '#/components/schemas/Message'
+          nullable: false
         status:
           description: >-
             One of a standardized set of short codes,
@@ -1009,20 +1026,23 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LogEntry'
-          nullable: true
+          minItems: 0
+          nullable: false
         workflow:
           description: List of workflow steps that were executed.
           # oneOf:
-          #   - $ref: http://standards.ncats.io/workflow/1.3.4/schema
+          #   - $ref: https://standards.ncats.io/workflow/1.3.5/schema
           nullable: true
         schema_version:
           type: string
           example: 1.4.0
           description: Version label of the TRAPI schema used in this document
+          nullable: true
         biolink_version:
           type: string
           example: 3.1.2
           description: Version label of the Biolink model used in this document
+          nullable: true
       additionalProperties: true
       required:
         - message
@@ -1042,11 +1062,16 @@ components:
           description: >-
             List of all returned Result objects for the query posed.
             The list SHOULD NOT be assumed to be ordered. The 'score' property,
-             if present, MAY be used to infer result rankings.
+            if present, MAY be used to infer result rankings. If Results are
+            not expected (such as for a query Message), this property SHOULD
+            be null or absent. If Results are expected (such as for a response
+            Message) and no Results are available, this property SHOULD be an
+            array with 0 Results in it.
           type: array
           items:
             $ref: '#/components/schemas/Result'
           nullable: true
+          minItems: 0
         query_graph:
           description: >-
             QueryGraph object that contains a serialization of a query in the
@@ -1142,6 +1167,8 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/NodeBinding'
+            minItems: 1
+          nullable: false 
         analyses:
           type: array
           description: >-
@@ -1149,6 +1176,8 @@ components:
             See below for Analysis components.
           items:
             $ref: '#/components/schemas/Analysis'
+          minItems: 0
+          nullable: false 
       additionalProperties: true
       required:
         - node_bindings
@@ -1164,7 +1193,9 @@ components:
           Binding must bind directly to node in the original Query Graph.
       properties:
         id:
-          $ref: '#/components/schemas/CURIE'
+          oneOf:
+            - $ref: '#/components/schemas/CURIE'
+          nullable: false
           description: >-
             The CURIE of a Node within the Knowledge Graph.
         query_id:
@@ -1190,10 +1221,12 @@ components:
             result.
           items:
             $ref: '#/components/schemas/Attribute'
-          nullable: true
+          minItems: 0
+          nullable: false
       additionalProperties: true
       required:
         - id
+        - attributes
     Analysis:
       type: object
       description: >-
@@ -1271,6 +1304,7 @@ components:
         id:
           type: string
           description: The key identifier of a specific KnowledgeGraph Edge.
+          nullable: false
         attributes:
           type: array
           description: >-
@@ -1280,10 +1314,12 @@ components:
             result.
           items:
             $ref: '#/components/schemas/Attribute'
-          nullable: true
+          minItems: 0
+          nullable: false
       additionalProperties: true
       required:
         - id
+        - attributes
     AuxiliaryGraph:
       type: object
       description: >-
@@ -1310,10 +1346,12 @@ components:
             Attributes of the Auxiliary Graph
           items:
             $ref: '#/components/schemas/Attribute'
-          nullable: true
+          minItems: 0
+          nullable: false
       additionalProperties: true
       required:
         - edges
+        - attributes
     KnowledgeGraph:
       type: object
       description: >-
@@ -1394,20 +1432,22 @@ components:
             $ref: '#/components/schemas/BiolinkEntity'
           minItems: 1
           nullable: true
-        is_set:
-          type: boolean
+        set_interpretation:
+          type: string
           description: >-
-            Boolean that if set to true, indicates that this QNode MAY have
-            multiple KnowledgeGraph Nodes bound to it within each Result.
-            The nodes in a set should be considered as a set of independent
-            nodes, rather than a set of dependent nodes, i.e., the answer
-            would still be valid if the nodes in the set were instead returned
-            individually. Multiple QNodes may have is_set=True. If a QNode
-            (n1) with is_set=True is connected to a QNode (n2) with
-            is_set=False, each n1 must be connected to n2. If a QNode (n1)
-            with is_set=True is connected to a QNode (n2) with is_set=True,
-            each n1 must be connected to at least one n2.
-          default: false
+            Indicates how multiple CURIEs in the ids property MUST be
+            interpreted. BATCH indicates that the query is intended to be
+            a batch query and each CURIE is treated independently. ALL means
+            that all specified CURIES MUST appear in each Result.
+            MANY means that member CURIEs MUST form one or more
+            sets in the Results, and sets with more members are generally
+            considered more desirable that sets with fewer members.
+            If this property is missing or null, the default is BATCH.
+          enum:
+            - BATCH
+            - ALL
+            - MANY
+          nullable: true
         constraints:
           type: array
           description: >-
@@ -1513,13 +1553,25 @@ components:
             categories should also be avoided.
           items:
             $ref: '#/components/schemas/BiolinkEntity'
-          nullable: true
+          minItems: 1
+          nullable: false
         attributes:
           type: array
           description: A list of attributes describing the node
           items:
             $ref: '#/components/schemas/Attribute'
-          nullable: true
+          minItems: 0
+          nullable: false
+        is_set:
+          type: boolean
+          description: >-
+            Indicates that the node represents a set of entities.
+            If this property is missing or null, it is assumed to be
+            false.
+          nullable: true        
+      required:
+        - categories
+        - attributes
       additionalProperties: false
     Attribute:
       type: object


### PR DESCRIPTION
For https://github.com/biothings/biothings_explorer/issues/802 / https://github.com/biothings/biothings_explorer/issues/485

Edit as-needed to add server urls for instances that have TRAPI 1.5 on them. 

DON'T MERGE until we're ready to advertise that we do TRAPI 1.5 for all instances. 

---

Note: updated
* info: 
    * biolink-version (also on dev/ci)
    * x-trapi version
    * x-trapi operation
* tags: for trapi version
* components/schema: done by looking at [git-compare](https://github.com/NCATSTranslator/ReasonerAPI/compare/v1.4.2...v1.5.0-beta), copying over changes. This worked because there weren't many changes
    * once done for BTE, I could just copy the whole components section over to the service-provider yaml