### PR TITLE
Corrected Syntax Error

### DIFF
--- a/AGR/agr.yaml
+++ b/AGR/agr.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for
     [AGR](https://www.alliancegenome.org/downloads) disease associations data.

--- a/DISEASES/smartapi.yaml
+++ b/DISEASES/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for [DISEASES](https://diseases.jensenlab.org/About) 
     data.

--- a/EBIgene2phenotype/smartapi.yaml
+++ b/EBIgene2phenotype/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for 
     [EBIgene2phenotype](https://www.ebi.ac.uk/gene2phenotype/) data.

--- a/MGIgene2phenotype/smartapi.yaml
+++ b/MGIgene2phenotype/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for Mouse Genome Informatics (MGI) 
     gene-phenotype and gene-disease data. See the metadata endpoint, 

--- a/bindingdb/smartapi.yaml
+++ b/bindingdb/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for 
     [BindingDB](https://www.bindingdb.org/rwd/bind/index.jsp) data.

--- a/bioplanet/bioplanet-pathway-disease.yaml
+++ b/bioplanet/bioplanet-pathway-disease.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for 
     [BioPlanet](https://tripod.nih.gov/bioplanet/#) pathway-disease data.

--- a/bioplanet/bioplanet-pathway-gene.yaml
+++ b/bioplanet/bioplanet-pathway-gene.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for 
 

--- a/ddinter/ddinter.yaml
+++ b/ddinter/ddinter.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for
     [DDInter](http://ddinter.scbdd.com/) data.

--- a/dgidb/openapi.yml
+++ b/dgidb/openapi.yml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for [DGIdb](https://dgidb.org/) 
     drug-gene interaction data.

--- a/dgidb/smartapi.yml
+++ b/dgidb/smartapi.yml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: Documentation of the BioThings DGIdb query web services.
   termsOfService: https://biothings.io/about
   title: BioThings DGIdb API

--- a/gtrx/gtrx.yaml
+++ b/gtrx/gtrx.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for [Genome-to-Treatment (GTRx™)](https://gtrx.rbsapp.net/about.html). 
     This API includes the content from the linked website, specifically the recommended acute treatments and 

--- a/hpo/smartapi.yaml
+++ b/hpo/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for [Human Phenotype Ontology](https://hpo.jax.org/app/) data.
   termsOfService: https://biothings.io/about

--- a/idisk/smartapi.yaml
+++ b/idisk/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for [iDISK](https://pubmed.ncbi.nlm.nih.gov/32068839/) 
     (integrated Dietary Supplement Knowledge Base) data.

--- a/innatedb/smartapi.yaml
+++ b/innatedb/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for [InnateDB](https://www.innatedb.com/) data. 
     InnateDB is a publicly available database of the genes, proteins, experimentally-verified interactions 

--- a/pfocr/smartapi.yaml
+++ b/pfocr/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for [Pathway Figure OCR (pfocr)](https://pfocr.wikipathways.org/) 
     data.

--- a/repodb/smartapi.yaml
+++ b/repodb/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for the Drug Repositioning Database, 
     [repoDB](https://unmtid-shinyapps.net/shiny/repodb/), data. 

--- a/rhea/smartapi.yaml
+++ b/rhea/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for [Rhea](https://www.rhea-db.org/) reaction data.
   termsOfService: https://biothings.io/about

--- a/semmeddb/version_without_operations.yaml
+++ b/semmeddb/version_without_operations.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for [SEMMEDDB](https://pubmed.ncbi.nlm.nih.gov/23044550/) 
     data (download data 

--- a/suppkg/suppkg.yaml
+++ b/suppkg/suppkg.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for
     [SuppKG](https://github.com/zhang-informatics/SemRep_DS/tree/main/SuppKG) data. SuppKG contains relations

--- a/uberon/smartapi.yaml
+++ b/uberon/smartapi.yaml
@@ -4,7 +4,7 @@ info:
     email: help@biothings.io
     name: BioThings Team
     x-id: https://github.com/biothings
-    x-role: responsible developers
+    x-role: responsible organization
   description: >-
     Documentation of the BioThings API for 
     [UBERON ontology](https://obophenotype.github.io/uberon/) data. 


### PR DESCRIPTION
When validating schemas, a syntax error was found in multiple repos, `info.contact.x-role: responsible developers`. This key has been modified to an accepted term. If in the schema the name is, `info.contact.name: "BioThings Team"`, the error key was updated to: `info.contact.x-role: responsible organization`,  else `info.contact.x-role: responsible developer`. 